### PR TITLE
[Feat/login#14] Github login FE,BE 연결 / Local Login 동작 확인 

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -126,4 +126,9 @@ dist
 # Serverless Webpack directories
 .webpack/
 
+
+
+.commitTemplate.txt
+.commitTemplate
+
 # End of https://www.toptal.com/developers/gitignore/api/node

--- a/backend/src/controllers/user-controller.ts
+++ b/backend/src/controllers/user-controller.ts
@@ -14,12 +14,12 @@ const UserController = {
 			const emailAlreadyUsed = await UserService.getInstance().getUserByEmail(user_email);
 			if (emailAlreadyUsed) return res.send('email is already in use');
 
-			const user_name = getUserName(user_email); // FE에서 ? BE에서?
+			const user_name = getUserName(user_email);
 
 			const newUser = await UserService.getInstance().createUser(user_email, encryptedPassword, user_name);
 			const JWT = createJWT(newUser.user_id);
 			res.cookie('JWT', JWT);
-			res.redirect('http://localhost:3000');
+			res.redirect(process.env.FRONT_URL);
 		} catch (err) {
 			res.send(err);
 		}
@@ -39,7 +39,7 @@ const UserController = {
 			const user = req.user as User;
 			const JWT = createJWT(user.user_id);
 			res.cookie('JWT', JWT);
-			res.redirect('http://localhost:3000');
+			res.redirect(process.env.FRONT_URL);
 		} catch (err) {
 			res.send(err);
 		}

--- a/backend/src/controllers/user-controller.ts
+++ b/backend/src/controllers/user-controller.ts
@@ -2,33 +2,32 @@ import UserService from '../services/user-service';
 import { User } from '../entities/user';
 
 import { Request, Response } from 'express';
-import bcrypt from 'bcrypt';
 import { createJWT } from '../token';
 
-import { getUserName, SALT_OR_ROUND } from './utils';
+import { getUserName } from './utils';
 
 const UserController = {
 	async createUser(req: Request, res: Response) {
 		try {
-			const { user_email, user_password } = req.body;
+			const { user_email, encryptedPassword } = req.body;
 
 			const emailAlreadyUsed = await UserService.getInstance().getUserByEmail(user_email);
 			if (emailAlreadyUsed) return res.send('email is already in use');
 
 			const user_name = getUserName(user_email); // FE에서 ? BE에서?
-			const encryptedPassword = bcrypt.hashSync(user_password, SALT_OR_ROUND);
 
 			const newUser = await UserService.getInstance().createUser(user_email, encryptedPassword, user_name);
 			const JWT = createJWT(newUser.user_id);
-			res.status(200).send(JWT);
+			res.cookie('JWT', JWT);
+			res.redirect('http://localhost:3000');
 		} catch (err) {
 			res.send(err);
 		}
 	},
-	async getUser(req: Request, res: Response) {
+	async getUser(req: any, res: Response) {
 		try {
-			const targetUser = req.user as User;
-			const user = await UserService.getInstance().getUser(targetUser.user_id);
+			const user_id = req.user_id;
+			const user = await UserService.getInstance().getUser(user_id);
 			res.status(200).send(user);
 		} catch (err) {
 			res.send(err);
@@ -39,7 +38,8 @@ const UserController = {
 		try {
 			const user = req.user as User;
 			const JWT = createJWT(user.user_id);
-			res.status(200).send(JWT);
+			res.cookie('JWT', JWT);
+			res.redirect('http://localhost:3000');
 		} catch (err) {
 			res.send(err);
 		}

--- a/backend/src/controllers/utils.ts
+++ b/backend/src/controllers/utils.ts
@@ -1,2 +1,1 @@
 export const getUserName = (user_email: string) => user_email.split('@')[0];
-export const SALT_OR_ROUND = 5;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,7 +40,7 @@ class App {
 
 	private middleware() {
 		const corsOptions = {
-			origin: process.env.FRONT_HOST || 'http://localhost:3000',
+			origin: process.env.FRONT_URL || 'http://localhost:3000',
 			credentials: true
 		};
 		this.app.use(cors(corsOptions));
@@ -59,7 +59,7 @@ class App {
 
 		const corsOptions = {
 			cors: true,
-			origins: [process.env.FRONT_HOST || 'http://localhost:3000']
+			origins: [process.env.FRONT_URL || 'http://localhost:3000']
 		};
 
 		SocketIO.attach(this.server, corsOptions);

--- a/backend/src/passport/github-strategy.ts
+++ b/backend/src/passport/github-strategy.ts
@@ -5,7 +5,7 @@ import UserService from '../services/user-service';
 
 const GITHUB_CONFIG = {
 	clientID: process.env.GITHUB_CLIENT_ID,
-	clientSecret: process.env.GITHUB_CLIENT_SECRETE,
+	clientSecret: process.env.GITHUB_CLIENT_SECRET,
 	callbackURL: 'http://localhost:4000/api/auth/github/callback'
 };
 
@@ -13,6 +13,7 @@ async function githubLoginCallback(accessToken, refreshToken, profile, callback)
 	// user_email : id / user_password : node_id / user_name : name
 	const { id, node_id, name } = profile._json;
 	let user = await UserService.getInstance().getUserByEmail(id);
+	console.log(user);
 	if (!user) user = await UserService.getInstance().createUser(id, node_id, name);
 	return callback(null, user);
 }

--- a/backend/src/passport/github-strategy.ts
+++ b/backend/src/passport/github-strategy.ts
@@ -6,15 +6,20 @@ import UserService from '../services/user-service';
 const GITHUB_CONFIG = {
 	clientID: process.env.GITHUB_CLIENT_ID,
 	clientSecret: process.env.GITHUB_CLIENT_SECRET,
-	callbackURL: 'http://localhost:4000/api/auth/github/callback'
+	callbackURL: process.env.GITHUB_CALLBACK_URL
+};
+
+const getUserRawData = (userJson) => {
+	const user_email = userJson.id;
+	const user_password = userJson.node_id;
+	const user_name = userJson.name;
+	return { user_email, user_password, user_name };
 };
 
 async function githubLoginCallback(accessToken, refreshToken, profile, callback) {
-	// user_email : id / user_password : node_id / user_name : name
-	const { id, node_id, name } = profile._json;
-	let user = await UserService.getInstance().getUserByEmail(id);
-	console.log(user);
-	if (!user) user = await UserService.getInstance().createUser(id, node_id, name);
+	const { user_email, user_password, user_name } = getUserRawData(profile._json);
+	let user = await UserService.getInstance().getUserByEmail(user_email);
+	if (!user) user = await UserService.getInstance().createUser(user_email, user_password, user_name);
 	return callback(null, user);
 }
 

--- a/backend/src/passport/local-strategy.ts
+++ b/backend/src/passport/local-strategy.ts
@@ -7,18 +7,17 @@ import bcrypt from 'bcrypt';
 
 const LocalStrategy = passportLocal.Strategy;
 const LOCAL_CONFIG = {
-	usernameField: 'user_email', // <input name="user_email">
+	usernameField: 'user_email',
 	passwordField: 'user_password'
 };
 
 async function localLoginCallback(user_email, user_password, callback) {
-	// is there a user?
 	const user = await UserService.getInstance().getUserByEmail(user_email);
 	if (!user) return callback(null, undefined, { reason: 'user does not exist' });
-	// is password validate?
+
 	const isValidPassword = await bcrypt.compare(user_password, user.user_password);
 	if (!isValidPassword) return callback(null, undefined, { reason: 'wrong password' });
-	// ok
+
 	return callback(null, user);
 }
 

--- a/backend/src/routes/auth-router.ts
+++ b/backend/src/routes/auth-router.ts
@@ -10,7 +10,7 @@ const router = express.Router();
 router.post(
 	'/login',
 	passport.authenticate('local', {
-		failureRedirect: '/login'
+		failureRedirect: '/'
 	}),
 	UserController.login
 );
@@ -19,6 +19,6 @@ router.post('/signup', UserController.createUser);
 router.get('/github', passport.authenticate('github'));
 router.get('/github/callback', passport.authenticate('github'), UserController.login);
 
-router.post('/info', authenticateToken, UserController.getUser);
+router.get('/info', authenticateToken, UserController.getUser);
 
 export default router;

--- a/backend/src/services/user-service.ts
+++ b/backend/src/services/user-service.ts
@@ -23,12 +23,12 @@ class UserService {
 			throw new Error('Not Found User');
 		}
 
-		const { user_id, user_email, user_name } = user;
-		return { user_id, user_email, user_name };
+		const { user_id, user_email, user_name, user_state } = user;
+		return { user_id, user_email, user_name, user_state };
 	}
 
 	async createUser(user_email: string, user_password: string, user_name: string) {
-		const newUser = await this.userRepository.save({ user_email, user_password, user_name, user_state: '자리 비움' });
+		const newUser = await this.userRepository.save({ user_email, user_password, user_name, user_state: 0 });
 		return newUser;
 	}
 

--- a/backend/src/token/index.ts
+++ b/backend/src/token/index.ts
@@ -1,17 +1,18 @@
+import { Request, Response } from 'express';
 import * as JWT from 'jsonwebtoken';
 
-export function authenticateToken(req, res, next) {
+export function authenticateToken(req: any, res: Response, next) {
 	const requestHeader = req.headers['authorization'];
 	const accessToken = requestHeader && requestHeader.split(' ')[1];
 
 	if (!accessToken) req.user = undefined;
 
-	JWT.default.verify(accessToken, process.env.JWT_SECRET_KEY, (err: Error, payload: Number) => {
-		if (err) req.user = undefined;
-		req.user = payload;
+	JWT.default.verify(accessToken, process.env.JWT_SECRET_KEY, (err: Error, payload: number) => {
+		if (err) req.user_id = undefined;
+		req.user_id = payload;
 	});
 
 	next();
 }
 
-export const createJWT = (user_id: Number) => JWT.default.sign(user_id, process.env.JWT_SECRET_KEY);
+export const createJWT = (user_id: number) => JWT.default.sign(user_id, process.env.JWT_SECRET_KEY);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,10 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "bcryptjs": "^2.4.3",
     "dotenv": "^10.0.0",
     "react": "^17.0.2",
+    "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
     "react-router": "^5.2.1",
@@ -46,6 +48,7 @@
     ]
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",
     "@types/react": "^17.0.33",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-toastify": "^8.0.3",
     "recoil": "^0.4.1",
     "socket.io-client": "^4.3.2",
     "styled-components": "^5.3.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,20 +2,25 @@ import React, { useEffect } from 'react';
 import socketIOClient from 'socket.io-client';
 import dotenv from 'dotenv';
 import { RecoilRoot } from 'recoil';
+import { ToastContainer } from 'react-toastify';
 import Router from './routes/router';
+import 'react-toastify/dist/ReactToastify.css';
 
 dotenv.config();
 
 const App: React.FC = () => {
 	useEffect(() => {
-		const socket = socketIOClient('http://localhost:4000');
+		const socket = socketIOClient(process.env.SERVER || 'http://localhost:4000');
 		socket.connect();
 	}, []);
 
 	return (
-		<RecoilRoot>
-			<Router />
-		</RecoilRoot>
+		<>
+			<RecoilRoot>
+				<Router />
+			</RecoilRoot>
+			<ToastContainer />
+		</>
 	);
 };
 

--- a/frontend/src/apis/auth.ts
+++ b/frontend/src/apis/auth.ts
@@ -1,9 +1,16 @@
+import bcrypt from 'bcryptjs';
+import { SALT_OR_ROUND } from '../utils/constants';
 import fetchApi from '../utils/fetch';
 
 export const login = ({ userEmail, userPassword }: { userEmail: string; userPassword: string }) => {
-	return fetchApi.post('/api/auth/login', { userEmail, userPassword });
+	const encryptedPassword = bcrypt.hashSync(userPassword, SALT_OR_ROUND);
+	return fetchApi.post('/api/auth/login', { userEmail, encryptedPassword });
 };
 
 export const githubLogin = () => {
-	window.location.href = `${process.env.SERVER ?? 'http://localhost:4000'}/auth/github`;
+	window.location.href = `${process.env.SERVER ?? 'http://localhost:4000'}/api/auth/github`;
+};
+
+export const check = () => {
+	return fetchApi.get('/api/auth/info');
 };

--- a/frontend/src/apis/auth.ts
+++ b/frontend/src/apis/auth.ts
@@ -1,16 +1,53 @@
 import bcrypt from 'bcryptjs';
+import { toast } from 'react-toastify';
 import { SALT_OR_ROUND } from '../utils/constants';
 import fetchApi from '../utils/fetch';
 
-export const login = ({ userEmail, userPassword }: { userEmail: string; userPassword: string }) => {
+/**
+ * @param cb: 로그인 확인 성공시 콜백 함수
+ * @param err: 로그인 확인 실패시 콜백 함수
+ */
+export const login = async (
+	{ userEmail, userPassword }: { userEmail: string; userPassword: string },
+	cb?: any,
+	err?: any,
+) => {
 	const encryptedPassword = bcrypt.hashSync(userPassword, SALT_OR_ROUND);
-	return fetchApi.post('/api/auth/login', { userEmail, encryptedPassword });
+	try {
+		const res = await fetchApi.post('/api/auth/login', { userEmail, encryptedPassword });
+		const data = await res.json();
+		if (res.status === 200) {
+			toast.success('😃 로그인 성공');
+			cb(data);
+		}
+		if (res.status === 401) {
+			toast.error('😣 존재하지 않는 계정입니다!');
+			err();
+		}
+	} catch (err) {
+		toast.error('😣 서버와의 연결이 심상치 않습니다!');
+	}
 };
 
 export const githubLogin = () => {
 	window.location.href = `${process.env.SERVER ?? 'http://localhost:4000'}/api/auth/github`;
 };
 
-export const check = () => {
-	return fetchApi.get('/api/auth/info');
+/**
+ * @param cb: 로그인 확인 성공시 콜백 함수
+ * @param err: 로그인 확인 실패시 콜백 함수
+ */
+export const check = async (cb?: any, err?: any) => {
+	try {
+		const res = await fetchApi.get('/api/auth/info');
+		const data = await res.json();
+		if (res.status === 200) {
+			cb(data);
+		}
+		if (res.status === 401) {
+			err();
+		}
+	} catch (err) {
+		toast.error('😣 서버와의 연결이 심상치 않습니다!');
+	}
 };

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -1,13 +1,9 @@
-import React, { useState } from 'react';
-import { useHistory } from 'react-router';
-import { useSetRecoilState } from 'recoil';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { AiFillGithub } from 'react-icons/ai';
 
 import { Container, BtnContainer, Input, Button, LogoWrapper } from './style';
 import { githubLogin, login } from '../../apis/auth';
-
-import UserState from '../../stores/user';
 
 interface Props {
 	inputEmailHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -27,14 +23,8 @@ const Logo: React.FC = () => {
 };
 
 const Login: React.FC<Props> = ({ inputEmailHandler, inputPwHandler, email, pw }: Props) => {
-	const history = useHistory();
-	const setUser = useSetRecoilState(UserState);
-	const localLoginHandler = async () => {
-		const user: any = await login({ userEmail: email, userPassword: pw });
-		if (user) {
-			setUser({ name: user?.user_name, email: user?.user_email, state: user?.user_state });
-			history.push('/team');
-		}
+	const localLoginHandler = () => {
+		login({ userEmail: email, userPassword: pw });
 	};
 	const githubLoginHandler = () => {
 		githubLogin();

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -1,9 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useHistory } from 'react-router';
+import { useSetRecoilState } from 'recoil';
 import { Link } from 'react-router-dom';
 import { AiFillGithub } from 'react-icons/ai';
 
 import { Container, BtnContainer, Input, Button, LogoWrapper } from './style';
-import { githubLogin } from '../../apis/auth';
+import { githubLogin, login } from '../../apis/auth';
+
+import UserState from '../../stores/user';
+
+interface Props {
+	inputEmailHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	inputPwHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	email: string;
+	pw: string;
+}
 
 const Logo: React.FC = () => {
 	return (
@@ -15,18 +26,27 @@ const Logo: React.FC = () => {
 	);
 };
 
-const Login: React.FC = () => {
+const Login: React.FC<Props> = ({ inputEmailHandler, inputPwHandler, email, pw }: Props) => {
+	const history = useHistory();
+	const setUser = useSetRecoilState(UserState);
+	const localLoginHandler = async () => {
+		const user: any = await login({ userEmail: email, userPassword: pw });
+		if (user) {
+			setUser({ name: user?.user_name, email: user?.user_email, state: user?.user_state });
+			history.push('/team');
+		}
+	};
 	const githubLoginHandler = () => {
 		githubLogin();
 	};
 	return (
 		<Container>
 			<Logo />
-			<Input type='email' placeholder='아이디를 입력' />
-			<Input type='password' placeholder='비밀번호를 입력' />
+			<Input type='email' placeholder='이메일을 입력' onChange={inputEmailHandler} />
+			<Input type='password' placeholder='비밀번호를 입력' onChange={inputPwHandler} />
 			<BtnContainer direction='column' gap='1rem'>
 				<BtnContainer direction='row' gap='2rem'>
-					<Button>
+					<Button onClick={localLoginHandler}>
 						<span>Login</span>
 					</Button>
 					<Button>

--- a/frontend/src/pages/LoginPage/index.tsx
+++ b/frontend/src/pages/LoginPage/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
 import { useSetRecoilState } from 'recoil';
+import { toast } from 'react-toastify';
 
 import LoginTemplate from '../../templates/LoginTemplate';
 import { check } from '../../apis/auth';
-import { setHeader } from '../../utils/fetch';
 import { getCookie } from '../../utils/cookie';
 import UserState from '../../stores/user';
 
@@ -21,16 +21,15 @@ const LoginPage: React.FC = () => {
 		setPw(e.target.value);
 	};
 	useEffect(() => {
-		setHeader(JWT);
 		if (JWT) {
 			localStorage.setItem('JWT', JWT);
-			document.cookie = '';
 			history.push('/team');
-		}
-		if (localStorage.getItem('JWT')) {
-			check().then((res: any) => {
+			toast.success('😎 Github 로그인 성공');
+		} else if (localStorage.getItem('JWT')) {
+			check((res: any) => {
 				setUser({ name: res?.user_name, email: res?.user_email, state: res.user_state });
 				history.push('/team');
+				toast.success('😎 자동 로그인 성공');
 			});
 		}
 	}, []);

--- a/frontend/src/pages/LoginPage/index.tsx
+++ b/frontend/src/pages/LoginPage/index.tsx
@@ -1,8 +1,41 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router';
+import { useSetRecoilState } from 'recoil';
+
 import LoginTemplate from '../../templates/LoginTemplate';
+import { check } from '../../apis/auth';
+import { setHeader } from '../../utils/fetch';
+import { getCookie } from '../../utils/cookie';
+import UserState from '../../stores/user';
 
 const LoginPage: React.FC = () => {
-	return <LoginTemplate />;
+	const JWT = getCookie('JWT');
+	const history = useHistory();
+	const setUser = useSetRecoilState(UserState);
+	const [email, setEmail] = useState('');
+	const [pw, setPw] = useState('');
+	const inputEmailHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setEmail(e.target.value);
+	};
+	const inputPwHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setPw(e.target.value);
+	};
+	useEffect(() => {
+		setHeader(JWT);
+		if (JWT) {
+			localStorage.setItem('JWT', JWT);
+			document.cookie = '';
+			history.push('/team');
+		}
+		if (localStorage.getItem('JWT')) {
+			check().then((res: any) => {
+				setUser({ name: res?.user_name, email: res?.user_email, state: res.user_state });
+				history.push('/team');
+			});
+		}
+	}, []);
+
+	return <LoginTemplate inputEmailHandler={inputEmailHandler} inputPwHandler={inputPwHandler} email={email} pw={pw} />;
 };
 
 export default LoginPage;

--- a/frontend/src/pages/TeamPage/index.tsx
+++ b/frontend/src/pages/TeamPage/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import TeamTemplate from '../../templates/TeamTemplate';
+
+const TeamPage: React.FC = () => {
+	return <TeamTemplate />;
+};
+
+export default TeamPage;

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
@@ -11,9 +12,15 @@ import UserState from '../stores/user';
 
 const Router: React.FC = () => {
 	const setUser = useSetRecoilState(UserState);
-	check().then((res: any) => {
-		setUser({ name: res?.user_name, email: res?.user_email, state: res?.user_state });
-	});
+	const history = useHistory();
+	check(
+		(res: any) => {
+			setUser({ name: res?.user_name, email: res?.user_email, state: res?.user_state });
+		},
+		() => {
+			history.push('/');
+		},
+	);
 	return (
 		<BrowserRouter>
 			<Switch>

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import ChatPage from '../pages/ChatPage';
 import LoginPage from '../pages/LoginPage';
 import CalendarPage from '../pages/CalendarPage';
+import TeamPage from '../pages/TeamPage';
+import { check } from '../apis/auth';
+import UserState from '../stores/user';
 
 const Router: React.FC = () => {
+	const setUser = useSetRecoilState(UserState);
+	check().then((res: any) => {
+		setUser({ name: res?.user_name, email: res?.user_email, state: res?.user_state });
+	});
 	return (
 		<BrowserRouter>
 			<Switch>
 				<Route exact path='/' component={LoginPage} />
+				<Route path='/team' component={TeamPage} />
 				<Route path='/chat' component={ChatPage} />
 				<Route path='/calendar' component={CalendarPage} />
 			</Switch>

--- a/frontend/src/templates/LoginTemplate/index.tsx
+++ b/frontend/src/templates/LoginTemplate/index.tsx
@@ -3,6 +3,13 @@ import styled from 'styled-components';
 import Login from '../../components/Login';
 import { ColorCode } from '../../utils/constants';
 
+interface Props {
+	inputEmailHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	inputPwHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	email: string;
+	pw: string;
+}
+
 const Layout = styled.div`
 	display: flex;
 	width: 100vw;
@@ -12,11 +19,12 @@ const Layout = styled.div`
 	background-color: ${ColorCode.PRIMARY1};
 `;
 
-const LoginTemplate: React.FC = () => {
+const LoginTemplate: React.FC<Props> = ({ inputEmailHandler, inputPwHandler, email, pw }) => {
 	return (
 		<Layout>
-			<Login />
+			<Login inputEmailHandler={inputEmailHandler} inputPwHandler={inputPwHandler} email={email} pw={pw} />
 		</Layout>
 	);
 };
+
 export default LoginTemplate;

--- a/frontend/src/templates/TeamTemplate/index.tsx
+++ b/frontend/src/templates/TeamTemplate/index.tsx
@@ -1,11 +1,7 @@
-import React, { useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import React from 'react';
 import { Header, Navbar } from '../../components/common';
-import UserState from '../../stores/user';
 
 const Team: React.FC = () => {
-	const user = useRecoilValue(UserState);
-	console.dir(user);
 	return (
 		<>
 			<Header />

--- a/frontend/src/templates/TeamTemplate/index.tsx
+++ b/frontend/src/templates/TeamTemplate/index.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { Header, Navbar } from '../../components/common';
+import UserState from '../../stores/user';
+
+const Team: React.FC = () => {
+	const user = useRecoilValue(UserState);
+	console.dir(user);
+	return (
+		<>
+			<Header />
+			<Navbar />
+		</>
+	);
+};
+export default Team;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -17,4 +17,6 @@ enum ColorCode {
 	HOVER = '#6264a7',
 }
 
-export { ColorCode };
+const SALT_OR_ROUND = 5; // bcrypt level
+
+export { ColorCode, SALT_OR_ROUND };

--- a/frontend/src/utils/cookie.ts
+++ b/frontend/src/utils/cookie.ts
@@ -1,0 +1,7 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const getCookie: any = (name: string) => {
+	return cookies.get(name);
+};

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -1,8 +1,13 @@
-const headers = { 'Content-type': 'application/json;charset=utf-8' };
-
 const baseUrl = process.env.SERVER ?? 'http://localhost:4000';
 
+const headers: HeadersInit = new Headers();
+
 type RequestData = { [key: string]: string | number };
+
+export const setHeader = (JWT: string) => {
+	headers.set('Content-Type', 'application/json');
+	if (JWT) headers.set('Authorization', `Bearer ${JWT}`);
+};
 
 const fetchApi = {
 	get: (path: string): Promise<JSON> =>

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -1,48 +1,46 @@
 const baseUrl = process.env.SERVER ?? 'http://localhost:4000';
 
-const headers: HeadersInit = new Headers();
+const headers: HeadersInit = {
+	'Content-Type': 'application/json',
+	authorization: `Bearer ${localStorage.getItem('JWT')}`,
+};
 
 type RequestData = { [key: string]: string | number };
 
-export const setHeader = (JWT: string) => {
-	headers.set('Content-Type', 'application/json');
-	if (JWT) headers.set('Authorization', `Bearer ${JWT}`);
-};
-
 const fetchApi = {
-	get: (path: string): Promise<JSON> =>
+	get: (path: string): Promise<Response> =>
 		fetch(`${baseUrl}${path}`, {
 			method: 'GET',
 			mode: 'cors',
 			credentials: 'include',
 			headers,
-		}).then((res) => res.json()),
+		}),
 
-	post: (path: string, data: RequestData): Promise<JSON> =>
+	post: (path: string, data: RequestData): Promise<Response> =>
 		fetch(`${baseUrl}${path}`, {
 			method: 'POST',
 			mode: 'cors',
 			credentials: 'include',
 			headers,
 			body: JSON.stringify(data),
-		}).then((res) => res.json()),
+		}),
 
-	put: (path: string, data: RequestData): Promise<JSON> =>
+	put: (path: string, data: RequestData): Promise<Response> =>
 		fetch(`${baseUrl}${path}`, {
 			method: 'PUT',
 			mode: 'cors',
 			credentials: 'include',
 			headers,
 			body: JSON.stringify(data),
-		}).then((res) => res.json()),
+		}),
 
-	delete: (path: string): Promise<JSON> =>
+	delete: (path: string): Promise<Response> =>
 		fetch(`${baseUrl}${path}`, {
 			method: 'DELETE',
 			mode: 'cors',
 			credentials: 'include',
 			headers,
-		}).then((res) => res.json()),
+		}),
 };
 
 export default fetchApi;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3650,6 +3650,11 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9697,6 +9702,13 @@ react-scripts@4.0.3:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-toastify@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-8.0.3.tgz#7fbf65f69ec357aab8dd03c1496f9177aa92409a"
+  integrity sha512-rv3koC7f9lKKSkdpYgo/TGzgWlrB/aaiUInF1DyV7BpiM4kyTs+uhu6/r8XDMtBY2FOIHK+FlK3Iv7OzpA/tCA==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^17.0.2:
   version "17.0.2"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1898,6 +1898,16 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bcryptjs@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.2.tgz#e3530eac9dd136bfdfb0e43df2c4c5ce1f77dfae"
+  integrity sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==
+
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/eslint@^7.2.6":
   version "7.28.2"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.2.tgz#0ff2947cdd305897c52d5372294e8c76f351db68"
@@ -1936,7 +1946,7 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.9.tgz#1cfb6d60ef3822c589f18e70f8b12f9a28ce8724"
   integrity sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==
 
-"@types/hoist-non-react-statics@*":
+"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.0.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -3097,6 +3107,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
+bcryptjs@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
+
 bfj@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-7.0.2.tgz#1988ce76f3add9ac2913fd8ba47aad9e651bfbb2"
@@ -3836,6 +3851,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -9510,6 +9530,15 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-cookie@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.1.1.tgz#832e134ad720e0de3e03deaceaab179c4061a19d"
+  integrity sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.0.1"
+    hoist-non-react-statics "^3.0.0"
+    universal-cookie "^4.0.0"
+
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a"
@@ -11336,6 +11365,14 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+universal-cookie@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## 작업 내용
- [x] Github Login FE, BE 연결 
- [x] Local Login 동작 확인 
- [x] React toastify 일부 적용

## 주요 변경 사항
1. github login FE, BE 연결을 했습니다.
2. Local Login은 로그인이 되는 것을 확인했으나, 아직 Sign up page는 구현하지 않았습니다.
3. React-toastify를 일부 적용했습니다.

## 구현 스크린샷 (선택)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/87362456/140074782-86746279-bd2b-4b36-8bb4-bd971013e472.gif)

## 궁금한점

라우터에서 로그인을 한 번 체크하고,(모든 페이지마다 접속 시 로그인 체크하는 용도)
로그인 페이지에서 따로 한 번 체크해서(팀 선택 페이지로 redirect하는 용도)
`/`에 접속하게 되면 강제로 두 번을 체크하는데 좋은 방법이 없을까요..