### PR TITLE
[Feat/calendar#41#42] 일정 수정, 삭제, 모달 리팩토링

### DIFF
--- a/backend/src/controllers/schedule-controller.ts
+++ b/backend/src/controllers/schedule-controller.ts
@@ -29,7 +29,16 @@ const ScheduleController = {
 		} catch (err) {
 			res.send(err);
 		}
-	}
+	},
+	async deleteSchedule(req: Request, res: Response) {
+		try {
+			const scheduleId: number = Number(req.params.scheduleId);
+			const schedule = await ScheduleService.getInstance().deleteSchedule(scheduleId);
+			res.status(200).send();
+		} catch (err) {
+			res.send(err);
+		}
+	},
 };
 
 export default ScheduleController;

--- a/backend/src/routes/schedule-router.ts
+++ b/backend/src/routes/schedule-router.ts
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.post('/:teamId', ScheduleController.createSchedule);
 router.get('/:teamId', ScheduleController.getSchedule);
+router.delete('/:scheduleId', ScheduleController.deleteSchedule);
 
 export default router;

--- a/backend/src/services/schedule-service.ts
+++ b/backend/src/services/schedule-service.ts
@@ -37,6 +37,11 @@ class ScheduleService {
 
 		return schedules;
 	}
+
+	async deleteSchedule(schedule_id) {
+		const deleted = await this.scheduleRepository.delete({schedule_id});
+		return deleted;
+	}
 }
 
 export default ScheduleService;

--- a/frontend/src/apis/schedule.ts
+++ b/frontend/src/apis/schedule.ts
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import { toast } from 'react-toastify';
-import { ScheduleType } from '../components/Calendar/dataStructure';
 import fetchApi from '../utils/fetch';
 
 export interface ScheduleReqType {
+	schedule_id?: number;
 	title?: string;
 	start_date: string;
 	end_date: string;

--- a/frontend/src/apis/schedule.ts
+++ b/frontend/src/apis/schedule.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { toast } from 'react-toastify';
+import { ScheduleType } from '../components/Calendar/dataStructure';
 import fetchApi from '../utils/fetch';
 
 export interface ScheduleReqType {

--- a/frontend/src/apis/schedule.ts
+++ b/frontend/src/apis/schedule.ts
@@ -25,6 +25,23 @@ export const createNewSchedule = async (team_id: number, newSchedule: ScheduleRe
 	}
 };
 
+export const deleteSchedule = async (schedule_id: number): Promise<any> => {
+	try {
+		const res = await fetchApi.delete(`/api/schedule/${schedule_id}`);
+		if (res.status === 200) {
+			return true;
+		}
+		if (res.status === 404) {
+			toast.error('😣 일정 삭제에 실패하였습니다!');
+			return false;
+		}
+		return true;
+	} catch (err) {
+		toast.error('😣 일정  삭제에 실패하였습니다!');
+		return false;
+	}
+};
+
 export const getSchedules = async (teamId: number, firstDate: string, lastDate: string): Promise<any> => {
 	try {
 		const res = await fetchApi.get(`/api/schedule/${teamId}?start_date=${firstDate}&end_date=${lastDate}`);

--- a/frontend/src/components/Calendar/CalendarModal/index.tsx
+++ b/frontend/src/components/Calendar/CalendarModal/index.tsx
@@ -14,12 +14,13 @@ import Modal from '../../common/Modal';
 
 import { FormContainer, TitleContainer, TimeContainer, DeleteButtonWrapper } from './style';
 import { strToFormatString } from '../../../utils/calendar';
-import { createNewSchedule, ScheduleReqType } from '../../../apis/schedule';
+import { createNewSchedule, deleteSchedule, ScheduleReqType } from '../../../apis/schedule';
 import { ScheduleType } from '../dataStructure';
 
 interface Props {
 	handleModalClose: () => void;
 	updateSchedule: (newSchedule: ScheduleType) => void;
+	deleteScheduleById: (id: number) => void;
 }
 interface InputScheduleType {
 	title: string;
@@ -29,10 +30,11 @@ interface InputScheduleType {
 	content: string;
 }
 
-const CalendarModal: React.FC<Props> = ({ handleModalClose, updateSchedule }) => {
+const CalendarModal: React.FC<Props> = ({ handleModalClose, updateSchedule, deleteScheduleById }) => {
 	const repeatOptions: string[] = ['반복안함', '매일반복', '매주반복', '매월반복'];
 
 	const modalMode = useRecoilValue(ModalMode).mode;
+	const scheduleId = useRecoilValue(ModalSchedule).schedule_id;
 	const [modalSchedule, setModalSchedule] = useRecoilState(ModalSchedule);
 	const [selectedColor, setSelectedColor] = useState<number>(0);
 	const [selectedRepeat, setSelectedRepeat] = useState<number>(0);
@@ -81,6 +83,13 @@ const CalendarModal: React.FC<Props> = ({ handleModalClose, updateSchedule }) =>
 		}
 	};
 
+	const handleDeleteButtonClick = async (e: any) => {
+		e.preventDefault();
+		await deleteSchedule(scheduleId);
+		deleteScheduleById(scheduleId);
+		handleModalClose();
+	};
+
 	useEffect(() => {
 		const { title, color, repeat_id, start_date, end_date, content } = modalSchedule;
 		setSelectedColor(color);
@@ -113,7 +122,7 @@ const CalendarModal: React.FC<Props> = ({ handleModalClose, updateSchedule }) =>
 					setSelectedOption={setSelectedRepeat}
 				/>
 				<textarea ref={contentRef} defaultValue={inputSchedule?.content} placeholder='설명을 입력해 주세요' />
-				<DeleteButtonWrapper>
+				<DeleteButtonWrapper onClick={handleDeleteButtonClick}>
 					<FaTrashAlt />
 				</DeleteButtonWrapper>
 			</FormContainer>

--- a/frontend/src/components/Calendar/CalendarModal/index.tsx
+++ b/frontend/src/components/Calendar/CalendarModal/index.tsx
@@ -1,26 +1,24 @@
 /* eslint-disable camelcase */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { createPortal } from 'react-dom';
+
 import moment from 'moment';
 import { toast } from 'react-toastify';
 
 import { FaTrashAlt } from 'react-icons/fa';
-import { ModalMode, ModalSchedule } from '../../../../stores/calendar';
+import { ModalMode, ModalSchedule } from '../../../stores/calendar';
 
-import ColorPicker from '../../ColorPicker';
-import DropDown from '../../DropDown';
-import Button from '../../Button';
+import ColorPicker from '../../common/ColorPicker';
+import DropDown from '../../common/DropDown';
+import Modal from '../../common/Modal';
 
-import { Container, FormContainer, TitleContainer, TimeContainer, ButtonContainer, DeleteButtonWrapper } from './style';
-import { ColorCode } from '../../../../utils/constants';
-import { strToFormatString } from '../../../../utils/calendar';
-import { createNewSchedule, ScheduleReqType } from '../../../../apis/schedule';
+import { FormContainer, TitleContainer, TimeContainer, DeleteButtonWrapper } from './style';
+import { strToFormatString } from '../../../utils/calendar';
+import { createNewSchedule, ScheduleReqType } from '../../../apis/schedule';
 
 interface Props {
 	handleModalClose: () => void;
 }
-
 interface InputScheduleType {
 	title: string;
 	date: string;
@@ -30,7 +28,6 @@ interface InputScheduleType {
 }
 
 const CalendarModal: React.FC<Props> = ({ handleModalClose }) => {
-	const MODAL: Element = document.getElementById('modal')!;
 	const repeatOptions: string[] = ['반복안함', '매일반복', '매주반복', '매월반복'];
 
 	const modalMode = useRecoilValue(ModalMode).mode;
@@ -94,8 +91,8 @@ const CalendarModal: React.FC<Props> = ({ handleModalClose }) => {
 		});
 	}, [modalMode, modalSchedule]);
 
-	return createPortal(
-		<Container>
+	return (
+		<Modal handleModalClose={handleModalClose} handleSubmit={handleSubmit} removeSubmitButton={modalMode === 'read'}>
 			<FormContainer>
 				<TitleContainer>
 					<ColorPicker selectedColor={selectedColor} setSelectedColor={setSelectedColor} />
@@ -113,19 +110,12 @@ const CalendarModal: React.FC<Props> = ({ handleModalClose }) => {
 					setSelectedOption={setSelectedRepeat}
 				/>
 				<textarea ref={contentRef} defaultValue={inputSchedule?.content} placeholder='설명을 입력해 주세요' />
+				<DeleteButtonWrapper>
+					<FaTrashAlt />
+				</DeleteButtonWrapper>
 			</FormContainer>
-			<ButtonContainer>
-				{modalMode === 'create' ? (
-					<Button text='저장' handler={handleSubmit} backgroundColor={ColorCode.PRIMARY1} fontColor={ColorCode.WHITE} />
-				) : (
-					<DeleteButtonWrapper>
-						<FaTrashAlt />
-					</DeleteButtonWrapper>
-				)}
-				<Button text='닫기' handler={handleModalClose} backgroundColor={ColorCode.WHITE} fontColor={ColorCode.BLACK} />
-			</ButtonContainer>
-		</Container>,
-		MODAL,
+		</Modal>
 	);
 };
+
 export default CalendarModal;

--- a/frontend/src/components/Calendar/CalendarModal/index.tsx
+++ b/frontend/src/components/Calendar/CalendarModal/index.tsx
@@ -15,9 +15,11 @@ import Modal from '../../common/Modal';
 import { FormContainer, TitleContainer, TimeContainer, DeleteButtonWrapper } from './style';
 import { strToFormatString } from '../../../utils/calendar';
 import { createNewSchedule, ScheduleReqType } from '../../../apis/schedule';
+import { ScheduleType } from '../dataStructure';
 
 interface Props {
 	handleModalClose: () => void;
+	updateSchedule: (newSchedule: ScheduleType) => void;
 }
 interface InputScheduleType {
 	title: string;
@@ -27,7 +29,7 @@ interface InputScheduleType {
 	content: string;
 }
 
-const CalendarModal: React.FC<Props> = ({ handleModalClose }) => {
+const CalendarModal: React.FC<Props> = ({ handleModalClose, updateSchedule }) => {
 	const repeatOptions: string[] = ['반복안함', '매일반복', '매주반복', '매월반복'];
 
 	const modalMode = useRecoilValue(ModalMode).mode;
@@ -73,7 +75,8 @@ const CalendarModal: React.FC<Props> = ({ handleModalClose }) => {
 	const handleSubmit = async () => {
 		const newScheduleData = getScheduleData();
 		if (validateSchedule(newScheduleData)) {
-			createNewSchedule(1, newScheduleData);
+			const newSchedule = await createNewSchedule(1, newScheduleData);
+			updateSchedule(newSchedule);
 			handleModalClose();
 		}
 	};

--- a/frontend/src/components/Calendar/CalendarModal/style.ts
+++ b/frontend/src/components/Calendar/CalendarModal/style.ts
@@ -37,7 +37,7 @@ export const TimeContainer = styled.div`
 	}
 `;
 
-export const DeleteButtonWrapper = styled.button`
+export const ButtonContainer = styled.button`
 	position: absolute;
 	top: 1.5rem;
 	right: 1.5rem;
@@ -45,6 +45,7 @@ export const DeleteButtonWrapper = styled.button`
 	background-color: transparent;
 	padding: 0;
 	svg {
+		margin-left: 1rem;
 		color: ${ColorCode.LINE3};
 		cursor: pointer;
 		width: 1.2rem;

--- a/frontend/src/components/Calendar/CalendarModal/style.ts
+++ b/frontend/src/components/Calendar/CalendarModal/style.ts
@@ -1,25 +1,5 @@
 import styled from 'styled-components';
-import { ColorCode, Font } from '../../../../utils/constants';
-
-export const Container = styled.div`
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	width: 30rem;
-	background-color: ${ColorCode.WHITE};
-	box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
-	border-radius: 8px;
-	z-index: 25;
-	padding: 4rem 2rem 2rem 2rem;
-	box-sizing: border-box;
-	input {
-		border: none;
-		&:focus {
-			outline: none;
-		}
-	}
-`;
+import { ColorCode, Font } from '../../../utils/constants';
 
 export const FormContainer = styled.form`
 	textarea {
@@ -54,14 +34,6 @@ export const TimeContainer = styled.div`
 		font-family: inherit;
 		font-size: ${Font.SMALL};
 		cursor: pointer;
-	}
-`;
-
-export const ButtonContainer = styled.div`
-	display: flex;
-	justify-content: right;
-	button {
-		margin-left: 1rem;
 	}
 `;
 

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/day.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/day.tsx
@@ -1,28 +1,32 @@
 import React from 'react';
-import { DayWrapper, Schedule, DayNum } from './style';
+import { useSetRecoilState } from 'recoil';
 import { PrimaryPalette } from '../../../../utils/constants';
+import { ModalMode, ModalSchedule } from '../../../../stores/calendar';
+import { DayWrapper, Schedule, DayNum } from './style';
 
-interface DayProps {
+interface Props {
 	day: number;
 	idx: number;
 	schedules: any[];
+	handleModalOpen: () => void;
 }
 
-const Week: React.FC<DayProps> = ({ day, idx, schedules }: DayProps) => {
+const Week: React.FC<Props> = ({ day, idx, schedules, handleModalOpen }) => {
 	const getScheduleByDay = (day: number) => schedules.filter((obj) => new Date(obj.start_date).getDate() === day);
-	const showModal = (e: any): void => {
-		const result = schedules.find((obj): boolean => {
-			if (obj.title === e.target.innerText) return true;
-			return false;
-		});
-		console.log(result?.title, result?.start_date, result?.end_date, result?.content);
+
+	const setModalMode = useSetRecoilState(ModalMode);
+	const setModalSchedule = useSetRecoilState(ModalSchedule);
+	const handleScheduleClick = (schedule: any) => {
+		setModalMode({ mode: 'read' });
+		setModalSchedule(schedule);
+		handleModalOpen();
 	};
 	return (
 		<DayWrapper className={idx === 0 ? 'sunday' : ''}>
 			{day !== 0 ? <DayNum>{day}</DayNum> : null}
 			{getScheduleByDay(day).map((e) => {
 				return (
-					<Schedule key={e.schedule_id} onClick={showModal} color={PrimaryPalette[e.color]}>
+					<Schedule key={e.schedule_id} onClick={() => handleScheduleClick(e)} color={PrimaryPalette[e.color]}>
 						{e.title}
 					</Schedule>
 				);

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/index.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/index.tsx
@@ -7,9 +7,10 @@ import Week from './week';
 interface Props {
 	dateInfo: DateInfoType;
 	schedules: any[];
+	handleModalOpen: () => void;
 }
 
-const MonthContent: React.FC<Props> = ({ dateInfo, schedules }) => {
+const MonthContent: React.FC<Props> = ({ dateInfo, schedules, handleModalOpen }) => {
 	const getFirstDay = (month: number, year: number): number => new Date(`${year}-${month}-01`).getDay();
 	const firstDay = getFirstDay(dateInfo.month, dateInfo.year);
 	const lastDay = new Date(dateInfo.year, dateInfo.month, 0).getDate();
@@ -50,7 +51,7 @@ const MonthContent: React.FC<Props> = ({ dateInfo, schedules }) => {
 	return (
 		<ContentContainer>
 			{generateDays(firstDay, lastDay).map((week, i) => (
-				<Week key={uuidv4()} week={week} schedules={schedules} />
+				<Week key={uuidv4()} week={week} schedules={schedules} handleModalOpen={handleModalOpen} />
 			))}
 		</ContentContainer>
 	);

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/style.ts
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/style.ts
@@ -32,6 +32,7 @@ export const Schedule = styled.div<ScheduleProps>`
 	background-color: ${(props) => props.color || ColorCode.ORANGE};
 	padding: 0.5rem;
 	margin: 0.3rem 0;
+	color: ${ColorCode.BLACK};
 `;
 
 export const WeekContainer = styled.div`

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/style.ts
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/style.ts
@@ -22,6 +22,7 @@ export const DayWrapper = styled.div`
 		color: ${ColorCode.RED};
 	}
 	&:hover {
+		border-top: 1px solid ${ColorCode.LINE2};
 		background-color: ${ColorCode.BACKGROUND1};
 	}
 `;

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/week.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/week.tsx
@@ -3,16 +3,17 @@ import { v4 as uuidv4 } from 'uuid';
 import { WeekContainer } from './style';
 import Day from './day';
 
-interface WeekProps {
+interface Props {
 	week: number[];
 	schedules: any[];
+	handleModalOpen: () => void;
 }
 
-const Week: React.FC<WeekProps> = ({ week, schedules }: WeekProps) => {
+const Week: React.FC<Props> = ({ week, schedules, handleModalOpen }) => {
 	return (
 		<WeekContainer>
 			{week.map((day, idx) => (
-				<Day key={uuidv4()} day={day} idx={idx} schedules={schedules} />
+				<Day key={uuidv4()} day={day} idx={idx} schedules={schedules} handleModalOpen={handleModalOpen} />
 			))}
 		</WeekContainer>
 	);

--- a/frontend/src/components/Calendar/MonthlyCalendar/index.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/index.tsx
@@ -7,13 +7,18 @@ import MonthContent from './MonthContent';
 interface MonthlyCalendarProps {
 	dateInfo: DateInfoType;
 	schedules: any[];
+	handleModalOpen: () => void;
 }
 
-const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({ dateInfo, schedules }: MonthlyCalendarProps) => {
+const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
+	dateInfo,
+	schedules,
+	handleModalOpen,
+}: MonthlyCalendarProps) => {
 	return (
 		<Container>
 			<MonthHeader />
-			<MonthContent dateInfo={dateInfo} schedules={schedules} />
+			<MonthContent dateInfo={dateInfo} schedules={schedules} handleModalOpen={handleModalOpen} />
 		</Container>
 	);
 };

--- a/frontend/src/components/common/Modal/index.tsx
+++ b/frontend/src/components/common/Modal/index.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable camelcase */
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { ColorCode } from '../../../utils/constants';
+import { Container, ButtonContainer } from './style';
+import Button from '../Button';
+
+interface Props {
+	children: React.ReactNode;
+	handleModalClose: () => void;
+	handleSubmit: () => void;
+	removeSubmitButton: boolean;
+}
+
+const Modal: React.FC<Props> = ({ children, handleModalClose, handleSubmit, removeSubmitButton }) => {
+	const MODAL: Element = document.getElementById('modal')!;
+
+	return createPortal(
+		<Container>
+			{children}
+			<ButtonContainer>
+				{!removeSubmitButton && (
+					<Button text='저장' handler={handleSubmit} backgroundColor={ColorCode.PRIMARY1} fontColor={ColorCode.WHITE} />
+				)}
+				<Button text='닫기' handler={handleModalClose} backgroundColor={ColorCode.WHITE} fontColor={ColorCode.BLACK} />
+			</ButtonContainer>
+		</Container>,
+		MODAL,
+	);
+};
+export default Modal;

--- a/frontend/src/components/common/Modal/index.tsx
+++ b/frontend/src/components/common/Modal/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 	removeSubmitButton: boolean;
 }
 
-const Modal: React.FC<Props> = ({ children, handleModalClose, handleSubmit, removeSubmitButton }) => {
+const Modal: React.FC<Props> = ({ children, handleModalClose, handleSubmit, removeSubmitButton = false }) => {
 	const MODAL: Element = document.getElementById('modal')!;
 
 	return createPortal(

--- a/frontend/src/components/common/Modal/index.tsx
+++ b/frontend/src/components/common/Modal/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
-import React, { useState, useRef, useEffect } from 'react';
+import React from 'react';
 import { createPortal } from 'react-dom';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { ColorCode } from '../../../utils/constants';
 import { Container, ButtonContainer } from './style';
 import Button from '../Button';

--- a/frontend/src/components/common/Modal/style.ts
+++ b/frontend/src/components/common/Modal/style.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { ColorCode, Font } from '../../../utils/constants';
+
+export const Container = styled.div`
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	width: 30rem;
+	background-color: ${ColorCode.WHITE};
+	box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+	border-radius: 8px;
+	z-index: 25;
+	padding: 4rem 2rem 2rem 2rem;
+	box-sizing: border-box;
+	input {
+		border: none;
+		&:focus {
+			outline: none;
+		}
+	}
+`;
+
+export const ButtonContainer = styled.div`
+	display: flex;
+	justify-content: right;
+	button {
+		margin-left: 1rem;
+	}
+`;

--- a/frontend/src/stores/modal.ts
+++ b/frontend/src/stores/modal.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+export const ModalState = atom({
+	key: 'isModalVisible',
+	default: {
+		isModalVisible: false
+	},
+});

--- a/frontend/src/stores/modal.ts
+++ b/frontend/src/stores/modal.ts
@@ -1,8 +1,0 @@
-import { atom } from 'recoil';
-
-export const ModalState = atom({
-	key: 'isModalVisible',
-	default: {
-		isModalVisible: false
-	},
-});

--- a/frontend/src/templates/CalendarTemplate/index.tsx
+++ b/frontend/src/templates/CalendarTemplate/index.tsx
@@ -11,7 +11,7 @@ import { Header, Navbar } from '../../components/common';
 import CalendarHeader from '../../components/Calendar/CalendarHeader';
 import MonthlyCalendar from '../../components/Calendar/MonthlyCalendar';
 import WeeklyCalendar from '../../components/Calendar/WeeklyCalendar';
-import CalendarModal from '../../components/common/Modal/Calendar';
+import CalendarModal from '../../components/Calendar/CalendarModal';
 import { Layout, MainContainer, CalendarContainer } from './style';
 
 const Calendar: React.FC = () => {
@@ -33,23 +33,25 @@ const Calendar: React.FC = () => {
 	const handleModalClose = () => setIsModalVisible(false);
 	const changeCalendar = () => setIsMonthly(!isMonthly);
 
-	const changeToCurrDate = () => {
-		setDateInfo(getCurrDateInfo());
-	};
+	const changeToCurrDate = () => setDateInfo(getCurrDateInfo());
 	const changeToPrevDate = () => {
 		const { year, month, weeklyStartDate } = dateInfo;
-		const type = isMonthly ? 'monthly' : 'weekly';
-		setDateInfo(getPrevDateInfo(year, month, weeklyStartDate, type));
+		setDateInfo(getPrevDateInfo(year, month, weeklyStartDate, isMonthly));
 	};
 	const changeToNextDate = () => {
 		const { year, month, weeklyStartDate } = dateInfo;
-		const type = isMonthly ? 'monthly' : 'weekly';
-		setDateInfo(getNextDateInfo(year, month, weeklyStartDate, type));
+		setDateInfo(getNextDateInfo(year, month, weeklyStartDate, isMonthly));
 	};
+	// 월 -> 주 넘어갈 때 그 월의 첫째주를 보여준다?
+	// 원래 10월 24일이 startdate인 주를 보고 있었는데
+	// 월로 넘긴 다음에 11월로 바꾸고 다시 주로 돌아온다면
+	// 11월 첫째주가 보여지는데..
+	// year: month: weeklyStartDate: 첫째주의 일요일 date
 
 	useEffect(() => {
+		console.log('fetch schedules');
 		fetchSchedules();
-	}, [dateInfo]);
+	}, [dateInfo, isMonthly]);
 
 	return (
 		<Layout>
@@ -67,7 +69,7 @@ const Calendar: React.FC = () => {
 						dateInfo={dateInfo}
 					/>
 					{isMonthly ? (
-						<MonthlyCalendar dateInfo={dateInfo} schedules={schedules} />
+						<MonthlyCalendar dateInfo={dateInfo} schedules={schedules} handleModalOpen={handleModalOpen} />
 					) : (
 						<WeeklyCalendar dateInfo={dateInfo} schedules={schedules} handleModalOpen={handleModalOpen} />
 					)}

--- a/frontend/src/templates/CalendarTemplate/index.tsx
+++ b/frontend/src/templates/CalendarTemplate/index.tsx
@@ -29,9 +29,9 @@ const Calendar: React.FC = () => {
 		setSchedules(scheduleList);
 	};
 
-	const updateSchedule = (newSchedule: ScheduleType) => {
-		setSchedules([...schedules, newSchedule]);
-	};
+	const deleteScheduleById = (id: number) => setSchedules(schedules.filter((e) => e.schedule_id !== id));
+
+	const updateSchedule = (newSchedule: ScheduleType) => setSchedules([...schedules, newSchedule]);
 
 	const handleModalOpen = () => setIsModalVisible(true);
 	const handleModalClose = () => setIsModalVisible(false);
@@ -78,7 +78,13 @@ const Calendar: React.FC = () => {
 					)}
 				</CalendarContainer>
 			</MainContainer>
-			{isModalVisible && <CalendarModal handleModalClose={handleModalClose} updateSchedule={updateSchedule} />}
+			{isModalVisible && (
+				<CalendarModal
+					handleModalClose={handleModalClose}
+					updateSchedule={updateSchedule}
+					deleteScheduleById={deleteScheduleById}
+				/>
+			)}
 		</Layout>
 	);
 };

--- a/frontend/src/templates/CalendarTemplate/index.tsx
+++ b/frontend/src/templates/CalendarTemplate/index.tsx
@@ -29,9 +29,11 @@ const Calendar: React.FC = () => {
 		setSchedules(scheduleList);
 	};
 
-	const deleteScheduleById = (id: number) => setSchedules(schedules.filter((e) => e.schedule_id !== id));
-
-	const updateSchedule = (newSchedule: ScheduleType) => setSchedules([...schedules, newSchedule]);
+	const deleteScheduleById = (id: number) => setSchedules(schedules.filter((schedule) => schedule.schedule_id !== id));
+	const addSchedule = (newSchedule: ScheduleType) => setSchedules([...schedules, newSchedule]);
+	const updateScheduleById = (id: number, newSchedule: ScheduleType) => {
+		setSchedules([...schedules.filter((schedule) => schedule.schedule_id !== id), newSchedule]);
+	};
 
 	const handleModalOpen = () => setIsModalVisible(true);
 	const handleModalClose = () => setIsModalVisible(false);
@@ -81,8 +83,9 @@ const Calendar: React.FC = () => {
 			{isModalVisible && (
 				<CalendarModal
 					handleModalClose={handleModalClose}
-					updateSchedule={updateSchedule}
+					addSchedule={addSchedule}
 					deleteScheduleById={deleteScheduleById}
+					updateScheduleById={updateScheduleById}
 				/>
 			)}
 		</Layout>

--- a/frontend/src/templates/CalendarTemplate/index.tsx
+++ b/frontend/src/templates/CalendarTemplate/index.tsx
@@ -29,6 +29,10 @@ const Calendar: React.FC = () => {
 		setSchedules(scheduleList);
 	};
 
+	const updateSchedule = (newSchedule: ScheduleType) => {
+		setSchedules([...schedules, newSchedule]);
+	};
+
 	const handleModalOpen = () => setIsModalVisible(true);
 	const handleModalClose = () => setIsModalVisible(false);
 	const changeCalendar = () => setIsMonthly(!isMonthly);
@@ -49,7 +53,6 @@ const Calendar: React.FC = () => {
 	// year: month: weeklyStartDate: 첫째주의 일요일 date
 
 	useEffect(() => {
-		console.log('fetch schedules');
 		fetchSchedules();
 	}, [dateInfo, isMonthly]);
 
@@ -75,7 +78,7 @@ const Calendar: React.FC = () => {
 					)}
 				</CalendarContainer>
 			</MainContainer>
-			{isModalVisible && <CalendarModal handleModalClose={handleModalClose} />}
+			{isModalVisible && <CalendarModal handleModalClose={handleModalClose} updateSchedule={updateSchedule} />}
 		</Layout>
 	);
 };

--- a/frontend/src/utils/calendar.ts
+++ b/frontend/src/utils/calendar.ts
@@ -14,8 +14,8 @@ export const getCurrDateInfo = () => {
 	return { year: moment().year(), month: moment().month() + 1, weeklyStartDate: date };
 };
 
-export const getPrevDateInfo = (year: number, month: number, weeklyStartDate: Date, type: string) => {
-	if (type === 'monthly') {
+export const getPrevDateInfo = (year: number, month: number, weeklyStartDate: Date, isMonthly: boolean) => {
+	if (isMonthly) {
 		const date = moment([year, month - 1, 1]).subtract(1, 'months');
 		return { year: date.year(), month: date.month() + 1, weeklyStartDate };
 	}
@@ -23,8 +23,8 @@ export const getPrevDateInfo = (year: number, month: number, weeklyStartDate: Da
 	return { year: date.year(), month: date.month() + 1, weeklyStartDate: date.toDate() };
 };
 
-export const getNextDateInfo = (year: number, month: number, weeklyStartDate: Date, type: string) => {
-	if (type === 'monthly') {
+export const getNextDateInfo = (year: number, month: number, weeklyStartDate: Date, isMonthly: boolean) => {
+	if (isMonthly) {
 		const date = moment([year, month - 1, 1]).add(1, 'months');
 		return { year: date.year(), month: date.month() + 1, weeklyStartDate };
 	}


### PR DESCRIPTION
## 작업 내용
- [x] 일정 수정
- [x] 일정 삭제
- [x] 일정 변경 즉시 리렌더링
- [x] 모달 컴포넌트 재사용 가능하도록 분리
- [x] 월간 달력 모달 표시

## 주요 변경 사항
- 월간 달력에 일정을 클릭하였을 때 상세 모달이 표시되도록 하였습니다.
- 일정 수정 버튼을 눌렀을 때 모달의 모드가 변경되고 수정 요청이 전송되도록 하였습니다.
- 모달에서 삭제 버튼을 눌렀을 때 일정이 삭제되도록 하였습니다.
- 일정 추가, 수정, 삭제시 리렌더링 되도록 하였습니다.
- 모달 컴포넌트를 재사용 가능하도록 분리하였습니다. children으로 컴포넌트를 내려서 사용하시면 됩니다!

## 구현 스크린샷 (선택)
![](https://i.imgur.com/9bSljZK.gif)

## 궁금한점
useDate라는 custom hook이 있던데 아무 기능도 안해서 어떤 의도였는지 궁금합니다.