### PR TITLE
[로그인] 헤더 프로필 및 로그아웃

### DIFF
--- a/backend/src/entities/user.ts
+++ b/backend/src/entities/user.ts
@@ -17,6 +17,9 @@ export class User {
 	user_name: string;
 
 	@Column()
+	github_name?: string;
+
+	@Column()
 	user_state: number;
 
 	@OneToMany(() => TeamUser, (teamUser) => teamUser.user)

--- a/backend/src/passport/github-strategy.ts
+++ b/backend/src/passport/github-strategy.ts
@@ -19,7 +19,7 @@ const getUserRawData = (userJson) => {
 const githubLoginCallback = async (accessToken, refreshToken, profile, callback) => {
 	const { user_email, user_password, user_name } = getUserRawData(profile._json);
 	let user = await UserService.getInstance().getUserByEmail(user_email);
-	if (!user) user = await UserService.getInstance().createUser(user_email, user_password, user_name);
+	if (!user) user = await UserService.getInstance().createUser(user_email, user_password, user_name, user_name);
 	return callback(null, user);
 };
 

--- a/backend/src/services/user-service.ts
+++ b/backend/src/services/user-service.ts
@@ -32,7 +32,8 @@ class UserService {
 	async createUser(user_email: string, encryptedPassword: string, user_name: string) {
 		const decryptedPassword = Crypto.AES.decrypt(encryptedPassword, process.env.AES_KEY).toString();
 		const user_password = bcrypt.hashSync(decryptedPassword, Number(process.env.SALT_OR_ROUNDS));
-		const newUser = await this.userRepository.save({ user_email, user_password, user_name, user_state: 0 });
+		const user_state = Math.floor(Math.random() * 12); // TODO : user_color로 바꾸기
+		const newUser = await this.userRepository.save({ user_email, user_password, user_name, user_state });
 		return newUser;
 	}
 

--- a/backend/src/services/user-service.ts
+++ b/backend/src/services/user-service.ts
@@ -25,15 +25,15 @@ class UserService {
 			return undefined;
 		}
 
-		const { user_id, user_email, user_name, user_state } = user;
-		return { user_id, user_email, user_name, user_state };
+		const { user_id, user_email, user_name, user_state, github_name } = user;
+		return { user_id, user_email, user_name, user_state, github_name };
 	}
 
-	async createUser(user_email: string, encryptedPassword: string, user_name: string) {
+	async createUser(user_email: string, encryptedPassword: string, user_name: string, github_name?: string) {
 		const decryptedPassword = Crypto.AES.decrypt(encryptedPassword, process.env.AES_KEY).toString();
 		const user_password = bcrypt.hashSync(decryptedPassword, Number(process.env.SALT_OR_ROUNDS));
 		const user_state = Math.floor(Math.random() * 12); // TODO : user_color로 바꾸기
-		const newUser = await this.userRepository.save({ user_email, user_password, user_name, user_state });
+		const newUser = await this.userRepository.save({ user_email, user_password, user_name, user_state, github_name });
 		return newUser;
 	}
 

--- a/frontend/src/apis/auth.ts
+++ b/frontend/src/apis/auth.ts
@@ -1,5 +1,6 @@
 import AES from 'crypto-js/aes';
 import { toast } from 'react-toastify';
+import { removeCookie } from '../utils/cookie';
 import fetchApi from '../utils/fetch';
 
 /**
@@ -72,4 +73,11 @@ export const signUp = async (
 	} catch (err) {
 		toast.error('😣 서버와의 연결이 심상치 않습니다!');
 	}
+};
+
+export const logout = (cb: any) => {
+	localStorage.removeItem('JWT');
+	removeCookie('JWT');
+	// TODO: fetch, socket
+	cb();
 };

--- a/frontend/src/components/common/Header/ProfileSimple/Buttons/Account.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/Buttons/Account.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { GrUserSettings } from 'react-icons/gr';
+import { Container } from './style';
+
+type Props = {
+	onClick: () => void;
+};
+
+const AccountButton: React.FC<Props> = ({ onClick }) => {
+	return (
+		<Container onClick={onClick}>
+			<GrUserSettings />
+			<span>계정 관리</span>
+		</Container>
+	);
+};
+
+export default AccountButton;

--- a/frontend/src/components/common/Header/ProfileSimple/Buttons/Logout.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/Buttons/Logout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { GrLogout } from 'react-icons/gr';
+import { Container } from './style';
+
+type Props = {
+	onClick: () => void;
+};
+
+const LogoutButton: React.FC<Props> = ({ onClick }) => {
+	return (
+		<Container onClick={onClick}>
+			<GrLogout />
+			<span>로그아웃</span>
+		</Container>
+	);
+};
+
+export default LogoutButton;

--- a/frontend/src/components/common/Header/ProfileSimple/Buttons/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/Buttons/index.tsx
@@ -1,0 +1,2 @@
+export { default as AccountButton } from './Account';
+export { default as LogoutButton } from './Logout';

--- a/frontend/src/components/common/Header/ProfileSimple/Buttons/style.ts
+++ b/frontend/src/components/common/Header/ProfileSimple/Buttons/style.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import { ColorCode } from '../../../../../utils/constants';
+
+export const Container = styled.div`
+	display: flex;
+	gap: 0.5rem;
+	width: calc(100% - 3rem);
+	font-size: 0.9rem;
+	font-weight: 400;
+	padding: 0rem 1.5rem;
+	height: 2.5rem;
+	align-items: center;
+	cursor: pointer;
+	&:hover {
+		background-color: ${ColorCode.LINE2};
+	}
+	&:last-of-type {
+		border-radius: 0px 0px 8px 8px;
+	}
+`;

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/EmailBox.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/EmailBox.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { AiOutlineMail } from 'react-icons/ai';
+import { LinkContainer } from './style';
+
+type Props = {
+	email: string;
+};
+
+const EmailBox: React.FC<Props> = ({ email }) => {
+	return (
+		<LinkContainer href={`mailto:${email}`}>
+			<AiOutlineMail />
+			<span>{email}</span>
+		</LinkContainer>
+	);
+};
+
+export default EmailBox;

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/GithubBadge.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/GithubBadge.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { AiFillGithub } from 'react-icons/ai';
+import { LinkContainer } from './style';
+
+type Props = {
+	github: string;
+};
+
+const GithubBadge: React.FC<Props> = ({ github }) => {
+	return (
+		<LinkContainer href={`https://github.com/${github}`} target='_blank' rel='noopner noreferrer nofollow'>
+			<AiFillGithub />
+			<span>{github}</span>
+		</LinkContainer>
+	);
+};
+
+export default GithubBadge;

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/index.tsx
@@ -19,7 +19,8 @@ const TextInfo: React.FC<ProfileProps> = ({ user, status }) => {
 		<TextContainer>
 			<span>{name}</span>
 			<span>{email}</span>
-			{status && <span>대화 가능 | 상태 메시지 설정</span>}
+			{status === 'none' && <span>Online</span>}
+			{status !== 'none' && <span>대화 가능 | 상태 메시지 설정</span>}
 		</TextContainer>
 	);
 };

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ProfileIcon } from '../../..';
+import { Container, TextContainer } from './style';
+
+type User = {
+	name: string;
+	email: string;
+	state: number;
+};
+
+type ProfileProps = {
+	user: User;
+	status: string;
+};
+
+const TextInfo: React.FC<ProfileProps> = ({ user, status }) => {
+	const { name, email } = user;
+	return (
+		<TextContainer>
+			<span>{name}</span>
+			<span>{email}</span>
+			{status && <span>대화 가능 | 상태 메시지 설정</span>}
+		</TextContainer>
+	);
+};
+
+const UserInfo: React.FC<ProfileProps> = ({ user, status }) => {
+	const { name } = user;
+	const color = user.state;
+
+	return (
+		<Container>
+			<ProfileIcon name={name} color={color} status={status} width={5} isHover={false} />
+			<TextInfo user={user} status={status} />
+		</Container>
+	);
+};
+
+export default UserInfo;

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/index.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { ProfileIcon } from '../../..';
-import { Container, TextContainer } from './style';
+import EmailBox from './EmailBox';
+import GithubBadge from './GithubBadge';
+import { Container, NameContainer, TextContainer } from './style';
 
 type User = {
 	name: string;
 	email: string;
 	state: number;
+	github?: string;
 };
 
 type ProfileProps = {
@@ -14,11 +17,14 @@ type ProfileProps = {
 };
 
 const TextInfo: React.FC<ProfileProps> = ({ user, status }) => {
-	const { name, email } = user;
+	const { name, email, github } = user;
 	return (
 		<TextContainer>
-			<span>{name}</span>
-			<span>{email}</span>
+			<NameContainer>
+				<span>{name} |</span>
+				{github && <GithubBadge github={github} />}
+				{!github && <EmailBox email={email} />}
+			</NameContainer>
 			{status === 'none' && <span>Online</span>}
 			{status !== 'none' && <span>대화 가능 | 상태 메시지 설정</span>}
 		</TextContainer>
@@ -28,7 +34,7 @@ const TextInfo: React.FC<ProfileProps> = ({ user, status }) => {
 const UserInfo: React.FC<ProfileProps> = ({ user, status }) => {
 	const { name } = user;
 	const color = user.state;
-
+	console.log(user);
 	return (
 		<Container>
 			<ProfileIcon name={name} color={color} status={status} width={5} isHover={false} />

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/style.ts
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { ColorCode } from '../../../../../utils/constants';
 
 export const Container = styled.div`
 	display: flex;
@@ -10,8 +11,26 @@ export const Container = styled.div`
 export const TextContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	justify-content: space-between;
+	justify-content: space-around;
 	padding: 0.5rem 0;
-	font-size: 0.9rem;
+	font-size: 1rem;
 	font-weight: 500;
+`;
+
+export const LinkContainer = styled.a`
+	display: flex;
+	align-items: center;
+	gap: 0.2rem;
+	border: 1px solid ${ColorCode.BLACK};
+	border-radius: 4px;
+	padding: 0.1rem 0.3rem;
+	span {
+		font-size: 0.7rem;
+	}
+`;
+
+export const NameContainer = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
 `;

--- a/frontend/src/components/common/Header/ProfileSimple/UserInfo/style.ts
+++ b/frontend/src/components/common/Header/ProfileSimple/UserInfo/style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+	display: flex;
+	flex-direction: row;
+	padding: 0 1rem;
+	margin-bottom: 1rem;
+`;
+
+export const TextContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	padding: 0.5rem 0;
+	font-size: 0.9rem;
+	font-weight: 500;
+`;

--- a/frontend/src/components/common/Header/ProfileSimple/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { useHistory } from 'react-router';
+import UserState from '../../../../stores/user';
+import UserInfo from './UserInfo';
+import { Background, Container, Wrapper } from './style';
+import { AccountButton, LogoutButton } from './Buttons';
+
+interface ProfileSimpleProps {
+	status: string;
+	handleCloseModal: () => void;
+}
+
+const ProfileSimple: React.FC<ProfileSimpleProps> = ({ status, handleCloseModal }) => {
+	const history = useHistory();
+	const user = useRecoilValue(UserState);
+
+	return (
+		<Container>
+			<Wrapper>
+				<UserInfo user={user} status={status} />
+				<AccountButton
+					onClick={() => {
+						console.log('click account'); // TODO: 프로필 수정 Modal
+					}}
+				/>
+				<LogoutButton
+					onClick={() => {
+						console.log('click logout'); // TODO: 로그아웃
+					}}
+				/>
+			</Wrapper>
+			<Background onClick={handleCloseModal} />
+		</Container>
+	);
+};
+
+export default ProfileSimple;

--- a/frontend/src/components/common/Header/ProfileSimple/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/index.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router';
 import { toast } from 'react-toastify';
 import UserState from '../../../../stores/user';
 import UserInfo from './UserInfo';
-import { Background, Container, Wrapper } from './style';
+import { Background, Container, ModalContainer } from './style';
 import { AccountButton, LogoutButton } from './Buttons';
 import { logout } from '../../../../apis/auth';
 
@@ -25,7 +25,7 @@ const ProfileSimple: React.FC<ProfileSimpleProps> = ({ status, handleCloseModal 
 
 	return (
 		<Container>
-			<Wrapper>
+			<ModalContainer>
 				<UserInfo user={user} status={status} />
 				<AccountButton
 					onClick={() => {
@@ -33,7 +33,7 @@ const ProfileSimple: React.FC<ProfileSimpleProps> = ({ status, handleCloseModal 
 					}}
 				/>
 				<LogoutButton onClick={logoutHandler} />
-			</Wrapper>
+			</ModalContainer>
 			<Background onClick={handleCloseModal} />
 		</Container>
 	);

--- a/frontend/src/components/common/Header/ProfileSimple/index.tsx
+++ b/frontend/src/components/common/Header/ProfileSimple/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { useHistory } from 'react-router';
+import { toast } from 'react-toastify';
 import UserState from '../../../../stores/user';
 import UserInfo from './UserInfo';
 import { Background, Container, Wrapper } from './style';
 import { AccountButton, LogoutButton } from './Buttons';
+import { logout } from '../../../../apis/auth';
 
 interface ProfileSimpleProps {
 	status: string;
@@ -14,6 +16,12 @@ interface ProfileSimpleProps {
 const ProfileSimple: React.FC<ProfileSimpleProps> = ({ status, handleCloseModal }) => {
 	const history = useHistory();
 	const user = useRecoilValue(UserState);
+	const logoutHandler = () => {
+		logout(() => {
+			toast.success('😎 로그아웃 성공');
+			history.push('/');
+		});
+	};
 
 	return (
 		<Container>
@@ -24,11 +32,7 @@ const ProfileSimple: React.FC<ProfileSimpleProps> = ({ status, handleCloseModal 
 						console.log('click account'); // TODO: 프로필 수정 Modal
 					}}
 				/>
-				<LogoutButton
-					onClick={() => {
-						console.log('click logout'); // TODO: 로그아웃
-					}}
-				/>
+				<LogoutButton onClick={logoutHandler} />
 			</Wrapper>
 			<Background onClick={handleCloseModal} />
 		</Container>

--- a/frontend/src/components/common/Header/ProfileSimple/style.ts
+++ b/frontend/src/components/common/Header/ProfileSimple/style.ts
@@ -15,11 +15,11 @@ const dropAnimation = keyframes`
 export const Wrapper = styled.div`
 	position: absolute;
 	top: 2rem;
-	right: 2rem;
+	right: 1rem;
 	display: flex;
 	flex-direction: column;
 	width: 22rem;
-	box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.04);
+	box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.25);
 	background-color: ${ColorCode.WHITE};
 	border-radius: 8px;
 	z-index: 25;
@@ -31,6 +31,7 @@ export const Container = styled.div`
 	position: absolute;
 	display: block;
 	width: 100%;
+	left: 0;
 `;
 
 export const Background = styled.div`

--- a/frontend/src/components/common/Header/ProfileSimple/style.ts
+++ b/frontend/src/components/common/Header/ProfileSimple/style.ts
@@ -1,0 +1,44 @@
+import styled, { keyframes } from 'styled-components';
+import { ColorCode } from '../../../../utils/constants';
+
+const dropAnimation = keyframes`
+	0% {
+		opacity: 0;
+		transform: translateY(-0.5rem);
+	}
+	100% {
+		opacity: 1;
+		transform: translateY(0);
+	}
+`;
+
+export const Wrapper = styled.div`
+	position: absolute;
+	top: 2rem;
+	right: 2rem;
+	display: flex;
+	flex-direction: column;
+	width: 22rem;
+	box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.04);
+	background-color: ${ColorCode.WHITE};
+	border-radius: 8px;
+	z-index: 25;
+	padding: 2rem 0rem 0rem 0rem;
+	animation: ${dropAnimation} 0.5s ease-in-out 1;
+`;
+
+export const Container = styled.div`
+	position: absolute;
+	display: block;
+	width: 100%;
+`;
+
+export const Background = styled.div`
+	position: fixed;
+	top: 3rem;
+	left: 0;
+	display: block;
+	width: 100vw;
+	height: calc(100vh - 3rem);
+	z-index: 0;
+`;

--- a/frontend/src/components/common/Header/ProfileSimple/style.ts
+++ b/frontend/src/components/common/Header/ProfileSimple/style.ts
@@ -12,7 +12,7 @@ const dropAnimation = keyframes`
 	}
 `;
 
-export const Wrapper = styled.div`
+export const ModalContainer = styled.div`
 	position: absolute;
 	top: 2rem;
 	right: 1rem;

--- a/frontend/src/components/common/Header/index.tsx
+++ b/frontend/src/components/common/Header/index.tsx
@@ -1,22 +1,29 @@
-import React from 'react';
-import { useHistory } from 'react-router';
+import React, { useLayoutEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+import { useRecoilValue } from 'recoil';
 
 import { Container } from './style';
 import { LongLogo } from '../Logo';
 import ProfileIcon from '../Icons/ProfileIcon';
+import UserState from '../../../stores/user';
 
 const Header: React.FC = () => {
-	const history = useHistory();
+	const user = useRecoilValue(UserState);
+	const shortenName = user.name[0];
+	const [status, setStatus] = useState('green'); // TODO: Socket으로부터 status 받아오기
+	const location = useLocation();
 
-	const linkHome = (e: any) => {
-		e.preventDefault();
-		// history.push('/');
-	};
+	useLayoutEffect(() => {
+		// TODO: Socket으로부터 status 받아오기
+		if (location.pathname === '/team') {
+			setStatus('none');
+		}
+	}, []);
 
 	return (
 		<Container>
 			<LongLogo />
-			<ProfileIcon name='부' color='orange' status='green' />
+			<ProfileIcon name={shortenName} color={user.state} status={status} />
 		</Container>
 	);
 };

--- a/frontend/src/components/common/Header/index.tsx
+++ b/frontend/src/components/common/Header/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useHistory } from 'react-router';
-import { Container, LogoWrapper } from './style';
+
+import { Container } from './style';
+import { LongLogo } from '../Logo';
 import ProfileIcon from '../Icons/ProfileIcon';
 
 const Header: React.FC = () => {
@@ -13,12 +15,7 @@ const Header: React.FC = () => {
 
 	return (
 		<Container>
-			<LogoWrapper>
-				<a href='/' onClick={linkHome}>
-					<img src='logo.png' alt='logo' />
-					BoostTeams
-				</a>
-			</LogoWrapper>
+			<LongLogo />
 			<ProfileIcon name='부' color='orange' status='green' />
 		</Container>
 	);

--- a/frontend/src/components/common/Header/index.tsx
+++ b/frontend/src/components/common/Header/index.tsx
@@ -6,12 +6,29 @@ import { Container } from './style';
 import { LongLogo } from '../Logo';
 import ProfileIcon from '../Icons/ProfileIcon';
 import UserState from '../../../stores/user';
+import ProfileSimple from './ProfileSimple';
 
 const Header: React.FC = () => {
 	const user = useRecoilValue(UserState);
-	const shortenName = user.name[0];
 	const [status, setStatus] = useState('green'); // TODO: Socket으로부터 status 받아오기
+	const [showProfileSimple, setShowProfileSimple] = useState(false);
 	const location = useLocation();
+
+	const handleCloseModal = () => {
+		setShowProfileSimple(false);
+	};
+
+	const handleOpenModal = () => {
+		setShowProfileSimple(true);
+	};
+
+	const clickHandler = () => {
+		if (showProfileSimple) {
+			handleCloseModal();
+		} else {
+			handleOpenModal();
+		}
+	};
 
 	useLayoutEffect(() => {
 		// TODO: Socket으로부터 status 받아오기
@@ -23,7 +40,8 @@ const Header: React.FC = () => {
 	return (
 		<Container>
 			<LongLogo />
-			<ProfileIcon name={shortenName} color={user.state} status={status} />
+			<ProfileIcon name={user.name} color={user.state} status={status} onClick={clickHandler} width={3} />
+			{showProfileSimple && <ProfileSimple status={status} handleCloseModal={handleCloseModal} />}
 		</Container>
 	);
 };

--- a/frontend/src/components/common/Header/index.tsx
+++ b/frontend/src/components/common/Header/index.tsx
@@ -10,7 +10,7 @@ import ProfileSimple from './ProfileSimple';
 
 const Header: React.FC = () => {
 	const user = useRecoilValue(UserState);
-	const [status, setStatus] = useState('green'); // TODO: Socket으로부터 status 받아오기
+	const [status, setStatus] = useState('green'); // TODO: Socket으로부터 status 받아오기, Status 문자열로 관리 이대로 괜찮은가?
 	const [showProfileSimple, setShowProfileSimple] = useState(false);
 	const location = useLocation();
 

--- a/frontend/src/components/common/Header/style.ts
+++ b/frontend/src/components/common/Header/style.ts
@@ -9,18 +9,3 @@ export const Container = styled.header`
 	background-color: ${ColorCode.PRIMARY1};
 	padding: 0 1rem;
 `;
-
-export const LogoWrapper = styled.div`
-	a {
-		display: flex;
-		align-items: center;
-		text-decoration: none;
-		color: ${ColorCode.WHITE};
-		font-weight: bold;
-		font-size: 1.5rem;
-		img {
-			padding-right: 0.5rem;
-			width: 2rem;
-		}
-	}
-`;

--- a/frontend/src/components/common/Icons/ProfileIcon/index.tsx
+++ b/frontend/src/components/common/Icons/ProfileIcon/index.tsx
@@ -3,12 +3,12 @@ import { ColorCode, PrimaryPalette, SecondaryPalette } from '../../../../utils/c
 import { Container, ProfileIconContainer, Status } from './style';
 
 interface ProfileProps {
-	name: string;
-	color: number;
-	status: string;
-	width: number;
-	isHover?: boolean;
-	onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+	name: string; // 유저 name
+	color: number; // 유저 프로필 배경색 user_color
+	status: string; // 유저 상태 (대화 가능, 다른 용무중 ...)
+	width: number; // n rem으로 크기 결정
+	isHover?: boolean; // hover 효과 줄건가? (default: true)
+	onClick?: (e: React.MouseEvent<HTMLElement>) => void; // onClick Event
 }
 
 const Palette = [...PrimaryPalette, ...SecondaryPalette];

--- a/frontend/src/components/common/Icons/ProfileIcon/index.tsx
+++ b/frontend/src/components/common/Icons/ProfileIcon/index.tsx
@@ -6,21 +6,29 @@ interface ProfileProps {
 	name: string;
 	color: number;
 	status: string;
+	width: number;
+	isHover?: boolean;
+	onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
 const Palette = [...PrimaryPalette, ...SecondaryPalette];
 
-const ProfileIcon: React.FC<ProfileProps> = ({ name, color, status }: ProfileProps) => {
+const ProfileIcon: React.FC<ProfileProps> = ({ name, color, status, width, isHover, onClick }) => {
 	const backgroundColor = color === 6 ? ColorCode.WHITE : Palette[color]; // 6이면 header 색상과 같음
 	const fontColor = color === 8 || color === 9 || color === 11 ? ColorCode.WHITE : ColorCode.BLACK;
 	return (
-		<Container>
-			<ProfileIconContainer backgroundColor={backgroundColor} fontColor={fontColor}>
-				<span>{name}</span>
+		<Container onClick={onClick} width={`${width}rem`} isHover={isHover}>
+			<ProfileIconContainer backgroundColor={backgroundColor} fontColor={fontColor} width={`${width - 1}rem`}>
+				<span>{name[0]}</span>
 				{status === 'none' && <Status color={status} />}
 			</ProfileIconContainer>
 		</Container>
 	);
+};
+
+ProfileIcon.defaultProps = {
+	isHover: true,
+	onClick: undefined,
 };
 
 export default ProfileIcon;

--- a/frontend/src/components/common/Icons/ProfileIcon/index.tsx
+++ b/frontend/src/components/common/Icons/ProfileIcon/index.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
+import { ColorCode, PrimaryPalette, SecondaryPalette } from '../../../../utils/constants';
 import { Container, ProfileIconContainer, Status } from './style';
 
 interface ProfileProps {
 	name: string;
-	color: string;
+	color: number;
 	status: string;
 }
 
+const Palette = [...PrimaryPalette, ...SecondaryPalette];
+
 const ProfileIcon: React.FC<ProfileProps> = ({ name, color, status }: ProfileProps) => {
+	const backgroundColor = color === 6 ? ColorCode.WHITE : Palette[color]; // 6이면 header 색상과 같음
+	const fontColor = color === 8 || color === 9 || color === 11 ? ColorCode.WHITE : ColorCode.BLACK;
 	return (
 		<Container>
-			<ProfileIconContainer color={color}>
+			<ProfileIconContainer backgroundColor={backgroundColor} fontColor={fontColor}>
 				<span>{name}</span>
-				<Status color={status} />
+				{status === 'none' && <Status color={status} />}
 			</ProfileIconContainer>
 		</Container>
 	);

--- a/frontend/src/components/common/Icons/ProfileIcon/style.ts
+++ b/frontend/src/components/common/Icons/ProfileIcon/style.ts
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 import { ColorCode } from '../../../../utils/constants';
 
+interface ProfileIconContainerProps {
+	backgroundColor: string;
+	fontColor: string;
+}
+
 export const Container = styled.div`
 	width: 3rem;
 	height: 3rem;
@@ -12,7 +17,7 @@ export const Container = styled.div`
 	}
 `;
 
-export const ProfileIconContainer = styled.div`
+export const ProfileIconContainer = styled('div')<ProfileIconContainerProps>`
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -20,7 +25,8 @@ export const ProfileIconContainer = styled.div`
 	height: 2rem;
 	width: 2rem;
 	border-radius: 50%;
-	background-color: ${(props) => props.color || ColorCode.WHITE};
+	background-color: ${(props) => props.backgroundColor || ColorCode.WHITE};
+	color: ${(props) => props.fontColor || ColorCode.BLACK};
 	span {
 		font-weight: bold;
 	}

--- a/frontend/src/components/common/Icons/ProfileIcon/style.ts
+++ b/frontend/src/components/common/Icons/ProfileIcon/style.ts
@@ -1,20 +1,26 @@
 import styled from 'styled-components';
 import { ColorCode } from '../../../../utils/constants';
 
-interface ProfileIconContainerProps {
+interface ContainerProps {
+	width: string;
+	isHover?: boolean;
+}
+
+interface ProfileIconContainerProps extends ContainerProps {
 	backgroundColor: string;
 	fontColor: string;
 }
 
-export const Container = styled.div`
-	width: 3rem;
-	height: 3rem;
+export const Container = styled('div')<ContainerProps>`
+	height: ${(props) => props.width};
+	width: ${(props) => props.width};
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	&:hover {
-		background-color: ${ColorCode.HOVER};
+		background-color: ${(props) => (props.isHover ? ColorCode.HOVER : 'none')};
 	}
+	cursor: pointer;
 `;
 
 export const ProfileIconContainer = styled('div')<ProfileIconContainerProps>`
@@ -22,13 +28,15 @@ export const ProfileIconContainer = styled('div')<ProfileIconContainerProps>`
 	justify-content: center;
 	align-items: center;
 	position: relative;
-	height: 2rem;
-	width: 2rem;
+	height: ${(props) => props.width};
+	width: ${(props) => props.width};
 	border-radius: 50%;
 	background-color: ${(props) => props.backgroundColor || ColorCode.WHITE};
 	color: ${(props) => props.fontColor || ColorCode.BLACK};
 	span {
 		font-weight: bold;
+		font-size: calc(${(props) => props.width} / 2);
+		vertical-align: middle;
 	}
 `;
 

--- a/frontend/src/components/common/Logo/LongLogo.tsx
+++ b/frontend/src/components/common/Logo/LongLogo.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useHistory } from 'react-router';
+
+import { Wrapper } from './style';
+
+const LongLogo: React.FC = () => {
+	const history = useHistory();
+
+	const linkHome = (e: any) => {
+		e.preventDefault();
+		// history.push('/');
+	};
+
+	return (
+		<Wrapper>
+			<a href='/' onClick={linkHome}>
+				<img src='logo.png' alt='logo' />
+				BoostTeams
+			</a>
+		</Wrapper>
+	);
+};
+
+export default LongLogo;

--- a/frontend/src/components/common/Logo/index.tsx
+++ b/frontend/src/components/common/Logo/index.tsx
@@ -1,0 +1,1 @@
+export { default as LongLogo } from './LongLogo';

--- a/frontend/src/components/common/Logo/style.ts
+++ b/frontend/src/components/common/Logo/style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import { ColorCode } from '../../../utils/constants';
+
+export const Wrapper = styled.div`
+	a {
+		display: flex;
+		align-items: center;
+		text-decoration: none;
+		color: ${ColorCode.WHITE};
+		font-weight: bold;
+		font-size: 1.5rem;
+		img {
+			padding-right: 0.5rem;
+			width: 2rem;
+		}
+	}
+`;

--- a/frontend/src/components/common/Logo/style.ts
+++ b/frontend/src/components/common/Logo/style.ts
@@ -13,5 +13,8 @@ export const Wrapper = styled.div`
 			padding-right: 0.5rem;
 			width: 2rem;
 		}
+		&:visited {
+			color: ${ColorCode.WHITE};
+		}
 	}
 `;

--- a/frontend/src/components/common/Navbar/style.ts
+++ b/frontend/src/components/common/Navbar/style.ts
@@ -6,7 +6,7 @@ export const Container = styled.nav`
 	flex-direction: column;
 	align-items: center;
 	width: 4.2rem;
-	height: 100%;
+	height: calc(100% - 3rem); // 3rem : 헤더 높이
 	background-color: ${ColorCode.LINE1};
 `;
 

--- a/frontend/src/routes/PrivateRoute.tsx
+++ b/frontend/src/routes/PrivateRoute.tsx
@@ -11,7 +11,13 @@ const PrivateRoute = ({ component: Component, ...rest }: any) => {
 		if (localStorage.getItem('JWT')) {
 			check(
 				(res: any) => {
-					setUser({ name: res.user_name, email: res.user_email, state: res.user_state, team_id: 1 });
+					setUser({
+						name: res.user_name,
+						email: res.user_email,
+						state: res.user_state,
+						team_id: 1,
+						github: res.github_name,
+					});
 				},
 				() => {
 					localStorage.removeItem('JWT');

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -2,7 +2,7 @@ import { atom } from 'recoil';
 
 const UserState = atom({
 	key: 'userState',
-	default: { name: '', email: '', state: 0, team_id: 1 },
+	default: { name: '', email: '', state: 0, team_id: 1, github: '' },
 });
 
 export default UserState;

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -1,10 +1,15 @@
 import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
+import { ColorCode } from '../utils/constants';
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
   a {
     text-decoration: none;
+    color: ${ColorCode.BLACK};
+    &:visited {
+      color: ${ColorCode.BLACK};
+    }
   }
 `;
 


### PR DESCRIPTION
## 작업 내용

- [x] 리팩토링(컴포넌트 분리)
- [x] 프로필 아이콘 데이터 연동
- [x] 프로필 아이콘 클릭 시 modal
- [x] 로그아웃

## 주요 변경 사항

프로필 아이콘에 이름의 첫글자가 표시되게 했습니다.
프로필 배경색은 회원가입할 때 랜덤으로 부여되게 하였습니다.
- 일단은 conflict를 피하기 위해 오늘 스프린트 리뷰에서 쓰지 않기로 했던 user_state 엔티티를 사용했고, 추후에 user_color로 바꿀 생각입니다.
- 이 프로필 표시 방법은 나중에 오브젝트 스토리지로 대체할 임시 방편이라 일단 이렇게 하였습니다!

프로필 아이콘을 클릭하면 모달창이 뜨게 했습니다.
- 기존 Modal을 재사용하려고 했는데, 저장/취소 같은 버튼이 있지 않고 위치 잡는 것이 애매하다고 판단돼 따로 만들었습니다.

로그아웃을 클릭하면 JWT 토큰을 삭제하고, 로그인 페이지로 이동합니다.

## 구현 스크린샷 (선택)

![image](https://user-images.githubusercontent.com/42960217/140751940-e5609850-f14c-48d4-a60e-6ac363bab924.png)
![image](https://user-images.githubusercontent.com/42960217/140751963-627bb43c-4aff-40e8-9364-11edc7932215.png)


- 2021-11-09 스크럼 이후 리팩토링
![image](https://user-images.githubusercontent.com/42960217/140852760-4ce21377-871a-4525-947c-d25797746f8f.png)
![image](https://user-images.githubusercontent.com/42960217/140852802-ae5e1aaa-5caa-4d7c-a3fb-2697224be7b4.png)

## 궁금한점

스크린샷에 나와있다시피 깃허브 로그인 유저는 추가 테이블 엔티티 없이 그냥 깃허브 id를 이메일로 치다보니 이메일이 나와야하는 부분에 깃허브 id가 노출이 되네요..!
저 위치에 이메일 대신 깃허브 유저라고 명시할 지 vs 깃허브 계정에 있는 이메일을 연동할 지 등 대책을 강구해야 할 것 같습니다!
후자를 선택한다면 엔티티를 추가해야하는 상황이라 고려해야할 점이 많습니다..!