### PR TITLE
[팀 관리] #43#45#51 팀 선택 page 구현 중

### DIFF
--- a/backend/src/controllers/team-user-contorller.ts
+++ b/backend/src/controllers/team-user-contorller.ts
@@ -1,11 +1,10 @@
 import { Request, Response } from 'express';
 import TeamUserService from '../services/team-user-service';
-import { parseId } from '../utils/helper';
 
 const TeamUserController = {
 	async getTeam(req: any, res: Response) {
 		try {
-			const userId = Number(req.user_id);
+			const userId = req.user_id;
 			const teams = await TeamUserService.getInstance().getTeamsByUserId(userId);
 			res.status(200).send(teams);
 		} catch (err) {
@@ -15,7 +14,7 @@ const TeamUserController = {
 
 	async joinTeam(req: any, res: Response) {
 		try {
-			const userId = Number(req.user_id);
+			const userId = req.user_id;
 			await TeamUserService.getInstance().joinTeam(userId, req.body);
 			res.status(200).send('good');
 		} catch (err) {
@@ -23,9 +22,9 @@ const TeamUserController = {
 		}
 	},
 
-	async createTeam(req: Request, res: Response) {
+	async createTeam(req: any, res: Response) {
 		try {
-			const [userId] = parseId(req.path);
+			const userId = req.user_id;
 			await TeamUserService.getInstance().createNewTeam(userId, req.body);
 			res.status(200).send('creation success');
 		} catch (err) {
@@ -35,14 +34,12 @@ const TeamUserController = {
 
 	async updateTeam(req: Request, res: Response) {
 		try {
-			const [userId, teamId] = parseId(req.path);
 		} catch (err) {
 			res.status(400).send(err);
 		}
 	},
 	async deleteTeam(req: Request, res: Response) {
 		try {
-			const [userId, teamId] = parseId(req.path);
 		} catch (err) {
 			res.status(400).send(err);
 		}

--- a/backend/src/controllers/team-user-contorller.ts
+++ b/backend/src/controllers/team-user-contorller.ts
@@ -5,7 +5,7 @@ const TeamUserController = {
 	async getTeam(req: any, res: Response) {
 		try {
 			const userId = req.user_id;
-			const teams = await TeamUserService.getInstance().getTeamsByUserId(userId);
+			const teams = await TeamUserService.getInstance().getTeam(userId);
 			res.status(200).send(teams);
 		} catch (err) {
 			res.status(400).send(err);
@@ -25,21 +25,26 @@ const TeamUserController = {
 	async createTeam(req: any, res: Response) {
 		try {
 			const userId = req.user_id;
-			await TeamUserService.getInstance().createNewTeam(userId, req.body);
+			await TeamUserService.getInstance().createTeam(userId, req.body);
 			res.status(200).send('creation success');
 		} catch (err) {
 			res.status(400).send(err);
 		}
 	},
 
-	async updateTeam(req: Request, res: Response) {
+	async updateTeam(req: any, res: Response) {
 		try {
+			console.log(req.body);
+			await TeamUserService.getInstance().updateTeam(req.body);
+			res.status(200).send('update success');
 		} catch (err) {
 			res.status(400).send(err);
 		}
 	},
-	async deleteTeam(req: Request, res: Response) {
+	async deleteTeam(req: any, res: Response) {
 		try {
+			await TeamUserService.getInstance().deleteTeam(req.body);
+			res.status(200).send('delete success');
 		} catch (err) {
 			res.status(400).send(err);
 		}

--- a/backend/src/controllers/team-user-contorller.ts
+++ b/backend/src/controllers/team-user-contorller.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express';
 import TeamUserService from '../services/team-user-service';
-import { parseUserId } from '../utils/helper';
+import { parseId } from '../utils/helper';
 
 const TeamUserController = {
-	async getTeams(req: Request, res: Response) {
+	async getTeam(req: any, res: Response) {
 		try {
-			const userId = parseUserId(req.path);
+			const userId = Number(req.user_id);
 			const teams = await TeamUserService.getInstance().getTeamsByUserId(userId);
 			res.status(200).send(teams);
 		} catch (err) {
@@ -13,9 +13,19 @@ const TeamUserController = {
 		}
 	},
 
-	async createTeams(req: Request, res: Response) {
+	async joinTeam(req: any, res: Response) {
 		try {
-			const userId = parseUserId(req.path);
+			const userId = Number(req.user_id);
+			await TeamUserService.getInstance().joinTeam(userId, req.body);
+			res.status(200).send('good');
+		} catch (err) {
+			res.status(400).send(err);
+		}
+	},
+
+	async createTeam(req: Request, res: Response) {
+		try {
+			const [userId] = parseId(req.path);
 			await TeamUserService.getInstance().createNewTeam(userId, req.body);
 			res.status(200).send('creation success');
 		} catch (err) {
@@ -25,16 +35,14 @@ const TeamUserController = {
 
 	async updateTeam(req: Request, res: Response) {
 		try {
-			const userId = parseUserId(req.path);
-			const teamId = parseTeamId(req.path);
+			const [userId, teamId] = parseId(req.path);
 		} catch (err) {
 			res.status(400).send(err);
 		}
 	},
 	async deleteTeam(req: Request, res: Response) {
 		try {
-			const userId = parseUserId(req.path);
-			const teamId = parseTeamId(req.path);
+			const [userId, teamId] = parseId(req.path);
 		} catch (err) {
 			res.status(400).send(err);
 		}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,7 +52,7 @@ class App {
 		// this.app.use('/api/user', userRouter);
 		this.app.use('/api/auth', authRouter);
 		this.app.use('/api/schedule', scheduleRouter);
-		this.app.use('/api/users', teamUserRouter);
+		this.app.use('/api/team', teamUserRouter);
 	}
 
 	listen() {

--- a/backend/src/middlewares/token.ts
+++ b/backend/src/middlewares/token.ts
@@ -15,7 +15,7 @@ export const authenticateToken = (req: any, res: Response, next: NextFunction) =
 		return res.status(401).send({ msg: 'invalid JWT' });
 	}
 
-	req.user_id = user_id;
+	req.user_id = Number(user_id);
 	next();
 };
 

--- a/backend/src/routes/team-user-router.ts
+++ b/backend/src/routes/team-user-router.ts
@@ -7,6 +7,6 @@ router.post('/new', authenticateToken, TeamUserController.createTeam);
 router.post('/join', authenticateToken, TeamUserController.joinTeam);
 router.get('/', authenticateToken, TeamUserController.getTeam);
 router.put('/:team_id', authenticateToken, TeamUserController.updateTeam);
-router.delete('/:team_id', authenticateToken, TeamUserController.deleteTeam);
+router.delete('/:team_id', TeamUserController.deleteTeam);
 
 export default router;

--- a/backend/src/routes/team-user-router.ts
+++ b/backend/src/routes/team-user-router.ts
@@ -3,10 +3,10 @@ import TeamUserController from '../controllers/team-user-contorller';
 import { authenticateToken } from '../middlewares/token';
 const router = express.Router();
 
-router.post('/:user_id/teams', TeamUserController.createTeam);
+router.post('/new', authenticateToken, TeamUserController.createTeam);
 router.post('/join', authenticateToken, TeamUserController.joinTeam);
 router.get('/', authenticateToken, TeamUserController.getTeam);
-router.put('/:user_id/teams/:team_id', TeamUserController.updateTeam);
-router.delete('/:user_id/teams/:team_id', TeamUserController.deleteTeam);
+router.put('/:team_id', authenticateToken, TeamUserController.updateTeam);
+router.delete('/:team_id', authenticateToken, TeamUserController.deleteTeam);
 
 export default router;

--- a/backend/src/routes/team-user-router.ts
+++ b/backend/src/routes/team-user-router.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import TeamUserController from '../controllers/team-user-contorller';
+import { authenticateToken } from '../middlewares/token';
 const router = express.Router();
 
-router.post('/:user_id/teams', TeamUserController.getTeams);
-router.get('/:user_id/teams', TeamUserController.getTeams);
-router.put('/:user_id/team/:team_id', () => {});
-router.delete('/:user_id/team/:team_id', () => {});
+router.post('/:user_id/teams', TeamUserController.createTeam);
+router.post('/join', authenticateToken, TeamUserController.joinTeam);
+router.get('/', authenticateToken, TeamUserController.getTeam);
+router.put('/:user_id/teams/:team_id', TeamUserController.updateTeam);
+router.delete('/:user_id/teams/:team_id', TeamUserController.deleteTeam);
 
 export default router;

--- a/backend/src/services/team-user-service.ts
+++ b/backend/src/services/team-user-service.ts
@@ -22,7 +22,25 @@ export default class TeamUserService {
 		return TeamUserService.instance;
 	}
 
-	async getTeamsByUserId(userId: number) {
+	async updateTeam(team: teamInfo) {
+		await this.teamUserRepository
+			.createQueryBuilder()
+			.update('team')
+			.set({ team_name: team.team_name, team_desc: team.team_desc })
+			.where('team_id=:id', { id: team.team_id })
+			.execute();
+	}
+
+	async deleteTeam(team: teamInfo) {
+		await this.teamUserRepository
+			.createQueryBuilder()
+			.delete()
+			.from('team')
+			.where('team_id=:id', { id: team.team_id })
+			.execute();
+	}
+
+	async getTeam(userId: number) {
 		const teams = await this.SelectAllTeam(userId);
 		return teams;
 	}
@@ -33,7 +51,7 @@ export default class TeamUserService {
 		await this.InsertTeamUserRecord(userId, team.team_id);
 	}
 
-	async createNewTeam(userId: number, newTeam: teamInfo) {
+	async createTeam(userId: number, newTeam: teamInfo) {
 		const insertResult = await this.InsertTeamRecord(newTeam);
 		const newTeamId = insertResult.raw.insertId;
 		await this.InsertTeamUserRecord(userId, newTeamId);

--- a/backend/src/utils/helper.ts
+++ b/backend/src/utils/helper.ts
@@ -1,5 +1,0 @@
-export const parseId = (path: string) => {
-	const regex = /\/(?<userId>[\d]*)(\/teams\/)?(?<teamId>[\d]*)?/;
-	const userId = regex.exec(path).groups;
-	return Object.values(userId).map((value) => Number(value));
-};

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -1,7 +1,20 @@
+import { MutableRefObject } from 'react';
 import fetchApi from '../utils/fetch';
+import { CardData } from '../components/Team/CardList';
 
 export const readMyTeam = async () => {
 	const response = await fetchApi.get(`/api/team`);
 	const json = await response.json();
 	return json;
+};
+
+export const joinNewTeam = async (setLoadTrigger: (param: any) => void, cardData: MutableRefObject<CardData>) => {
+	// add 따로
+	const response = await fetchApi.post('/api/team/join', {
+		team_id: cardData.current.team.team_id,
+		team_name: cardData.current.team.team_name,
+		team_desc: cardData.current.team.team_desc,
+	});
+	// refresh 따로
+	setLoadTrigger((prev: number) => prev + 1);
 };

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -1,7 +1,7 @@
 import fetchApi from '../utils/fetch';
 
-export const readMyTeam = async (userEmail: string) => {
-	const response = await fetchApi.get(`/api/team/${userEmail}`);
+export const readMyTeam = async () => {
+	const response = await fetchApi.get(`/api/team`);
 	const json = await response.json();
 	return json;
 };

--- a/frontend/src/components/Team/CardList/index.tsx
+++ b/frontend/src/components/Team/CardList/index.tsx
@@ -4,23 +4,21 @@ import { userInviteList, userTeamList } from '../../../stores/team';
 import TeamCard from '../TeamCard';
 import { CardListContainer } from './style';
 
-interface TeamData {
+export interface TeamData {
 	team_id: number;
 	team_name: string;
 	team_desc: string;
 }
 interface Props {
-	dummy: TeamData[];
 	type: string;
 }
 
-const CardList: React.FC<Props> = ({ dummy, type }) => {
-	// const teamList = type === 'myTeam' ? useRecoilValue(userTeamList) : useRecoilState(userInviteList); // 개선 필요
-	const teamList = dummy;
+const CardList: React.FC<Props> = ({ type }) => {
+	const [list, setList] = type === 'myTeam' ? useRecoilValue(userTeamList) : useRecoilState(userInviteList);
 	return (
 		<CardListContainer>
-			{teamList.map((team: TeamData) => (
-				<TeamCard key={team.team_id} type={type} team_name={team.team_name} />
+			{list.map((team: TeamData) => (
+				<TeamCard key={team.team_id} type={type} teamData={team} />
 			))}
 		</CardListContainer>
 	);

--- a/frontend/src/components/Team/CardList/index.tsx
+++ b/frontend/src/components/Team/CardList/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { useRecoilValue } from 'recoil';
 import { userInviteList, userTeamList } from '../../../stores/team';
+
 import TeamCard from '../TeamCard';
 import { CardListContainer } from './style';
 

--- a/frontend/src/components/Team/CardList/index.tsx
+++ b/frontend/src/components/Team/CardList/index.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { userInviteList, userTeamList } from '../../../stores/team';
 import TeamCard from '../TeamCard';
 import { CardListContainer } from './style';
 
-export interface TeamData {
+interface TeamData {
 	team_id: number;
 	team_name: string;
 	team_desc: string;
+}
+export interface CardData {
+	team_user_id: number;
+	team: TeamData;
 }
 interface Props {
 	type: string;
 }
 
 const CardList: React.FC<Props> = ({ type }) => {
-	const [list, setList] = type === 'myTeam' ? useRecoilValue(userTeamList) : useRecoilState(userInviteList);
+	const teamList = useRecoilValue(type === 'myTeam' ? userTeamList : userInviteList);
 	return (
 		<CardListContainer>
-			{list.map((team: TeamData) => (
-				<TeamCard key={team.team_id} type={type} teamData={team} />
+			{teamList.map((team: CardData) => (
+				<TeamCard key={team.team_user_id} type={type} data={team} />
 			))}
 		</CardListContainer>
 	);

--- a/frontend/src/components/Team/CardList/style.ts
+++ b/frontend/src/components/Team/CardList/style.ts
@@ -1,11 +1,12 @@
-import Styled from 'styled-components';
+import styled from 'styled-components';
 
-export const CardListContainer = Styled.div`
-  display:grid;
-  grid-template-columns : repeat(auto-fill, minmax(20%, auto));
-  grid-templates-rows : repeat(auto-fill, minmax(33%, auto));
-  align-items: center;
-  justify-items: center;
-  top:3rem;
-  height: calc((100% - 3rem) / 2);
-  `;
+export const CardListContainer = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: 3rem;
+	align-items: center;
+	justify-items: center;
+	top: 3rem;
+	padding: 1rem;
+	height: calc((100% - 3rem) / 2 - 2rem); // 3rem: header, 2rem: padding
+`;

--- a/frontend/src/components/Team/TeamCard/index.tsx
+++ b/frontend/src/components/Team/TeamCard/index.tsx
@@ -1,18 +1,24 @@
 import React, { useRef, MouseEvent } from 'react';
 import { useHistory } from 'react-router';
 
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { userInviteList, teamListLoadTrigger } from '../../../stores/team';
+
 import { CardData } from '../CardList';
 
-import Button from '../../common/Button';
+import { joinNewTeam } from '../../../apis/team';
 
+import Button from '../../common/Button';
 import { TeamCardContainer, TeamCardImage, TeamCardName, InviteButtonContainer } from './style';
 
-export interface teamCardType {
+interface Props {
 	type: string;
 	data: CardData;
 }
 
-const TeamCard: React.FC<teamCardType> = ({ type, data }) => {
+const TeamCard: React.FC<Props> = ({ type, data }) => {
+	const [inviteList, setInviteList] = useRecoilState(userInviteList);
+	const setLoadTrigger = useSetRecoilState(teamListLoadTrigger);
 	const history = useHistory();
 	const cardData = useRef(data);
 
@@ -20,13 +26,17 @@ const TeamCard: React.FC<teamCardType> = ({ type, data }) => {
 	// recoil selector의 Setter 이용, DB의 team-user에 새로운 record 추가
 	const acceptHandler = (event: MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
+		joinNewTeam(setLoadTrigger, cardData);
 	};
-	// recoil atom의 배열에서 제거
 	const declineHandler = (event: MouseEvent<HTMLButtonElement>) => {
+		// https://stackoverflow.com/questions/63357128/recoil-not-persisting-state-when-refreshing-page
+		// recoil States는 state 영구적이지 않음, 어떻게 해결 ? local Storage ? DB
 		event.stopPropagation();
+		const newList = inviteList.filter((team) => team.team_user_id !== cardData.current.team_user_id);
+		setInviteList(newList);
 	};
 
-	// invitation Card는 클릭되면 안 됨
+	// invitation Card에는 teamChoiceHandler가 등록되면 안 됨 (개선 필요)
 	return (
 		<TeamCardContainer onClick={teamChoiceHandler}>
 			<TeamCardImage>

--- a/frontend/src/components/Team/TeamCard/index.tsx
+++ b/frontend/src/components/Team/TeamCard/index.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, { useRef, MouseEvent } from 'react';
+import { useHistory } from 'react-router';
+
+import { TeamData } from '../CardList';
 
 import Button from '../../common/Button';
 
@@ -6,24 +9,37 @@ import { TeamCardContainer, TeamCardImage, TeamCardName, InviteButtonContainer }
 
 export interface teamCardType {
 	type: string;
-	team_name: string;
+	teamData: TeamData;
 }
 
-const TeamCard: React.FC<teamCardType> = ({ type, team_name }) => {
-	const handleClick = () => {
-		console.log('hi');
+const TeamCard: React.FC<teamCardType> = ({ type, teamData }) => {
+	const history = useHistory();
+	const cardData = useRef(teamData);
+
+	const teamChoiceHandler = () => {
+		history.push(`team/${cardData.current.team_id}/calendar`);
+	};
+	// recoil selector의 Setter 이용, DB의 team-user에 새로운 record 추가
+	const acceptHandler = (event: MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		console.log('accept');
+	};
+	// recoil atom의 배열에서 제거
+	const declineHandler = (event: MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		console.log(cardData.current.team_id);
 	};
 
 	return (
-		<TeamCardContainer>
+		<TeamCardContainer onClick={teamChoiceHandler}>
 			<TeamCardImage>
 				<img src='/logo.png' alt='/logo.png' />
 			</TeamCardImage>
-			<TeamCardName>{team_name}</TeamCardName>
+			<TeamCardName>{teamData.team_name}</TeamCardName>
 			{type === 'invitation' ? (
 				<InviteButtonContainer>
-					<Button text='수락' backgroundColor='' fontColor='' handler={handleClick} />
-					<Button text='거절' backgroundColor='' fontColor='' handler={handleClick} />
+					<Button text='수락' backgroundColor='' fontColor='' handler={acceptHandler} />
+					<Button text='거절' backgroundColor='' fontColor='' handler={declineHandler} />
 				</InviteButtonContainer>
 			) : (
 				''

--- a/frontend/src/components/Team/TeamCard/index.tsx
+++ b/frontend/src/components/Team/TeamCard/index.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, MouseEvent } from 'react';
 import { useHistory } from 'react-router';
 
-import { TeamData } from '../CardList';
+import { CardData } from '../CardList';
 
 import Button from '../../common/Button';
 
@@ -9,33 +9,30 @@ import { TeamCardContainer, TeamCardImage, TeamCardName, InviteButtonContainer }
 
 export interface teamCardType {
 	type: string;
-	teamData: TeamData;
+	data: CardData;
 }
 
-const TeamCard: React.FC<teamCardType> = ({ type, teamData }) => {
+const TeamCard: React.FC<teamCardType> = ({ type, data }) => {
 	const history = useHistory();
-	const cardData = useRef(teamData);
+	const cardData = useRef(data);
 
-	const teamChoiceHandler = () => {
-		history.push(`team/${cardData.current.team_id}/calendar`);
-	};
+	const teamChoiceHandler = () => history.push(`team/${cardData.current.team.team_id}/calendar`);
 	// recoil selector의 Setter 이용, DB의 team-user에 새로운 record 추가
 	const acceptHandler = (event: MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
-		console.log('accept');
 	};
 	// recoil atom의 배열에서 제거
 	const declineHandler = (event: MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
-		console.log(cardData.current.team_id);
 	};
 
+	// invitation Card는 클릭되면 안 됨
 	return (
 		<TeamCardContainer onClick={teamChoiceHandler}>
 			<TeamCardImage>
 				<img src='/logo.png' alt='/logo.png' />
 			</TeamCardImage>
-			<TeamCardName>{teamData.team_name}</TeamCardName>
+			<TeamCardName>{cardData.current.team.team_name}</TeamCardName>
 			{type === 'invitation' ? (
 				<InviteButtonContainer>
 					<Button text='수락' backgroundColor='' fontColor='' handler={acceptHandler} />

--- a/frontend/src/components/common/Logo/LongLogo.tsx
+++ b/frontend/src/components/common/Logo/LongLogo.tsx
@@ -1,22 +1,15 @@
 import React from 'react';
-import { useHistory } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import { Wrapper } from './style';
 
 const LongLogo: React.FC = () => {
-	const history = useHistory();
-
-	const linkHome = (e: any) => {
-		e.preventDefault();
-		// history.push('/');
-	};
-
 	return (
 		<Wrapper>
-			<a href='/' onClick={linkHome}>
-				<img src='logo.png' alt='logo' />
+			<Link to='/'>
+				<img src='/logo.png' alt='logo' />
 				BoostTeams
-			</a>
+			</Link>
 		</Wrapper>
 	);
 };

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -14,13 +14,20 @@ const Router: React.FC = () => {
 		<BrowserRouter>
 			<Switch>
 				<PublicRoute exact path='/' component={LoginPage} />
-				<PublicRoute path='/signup' component={SignUpPage} />
-				<PrivateRoute path='/team' component={TeamPage} />
-				<PrivateRoute path='/chat' component={ChatPage} />
-				<PrivateRoute path='/calendar' component={CalendarPage} />
+				<PublicRoute exact path='/signup' component={SignUpPage} />
+				<PrivateRoute exact path='/team' component={TeamPage} />
+				<PrivateRoute exact path='/team/:team_id/chat' component={ChatPage} />
+				<PrivateRoute exact path='/team/:team_id/calendar' component={CalendarPage} />
 			</Switch>
 		</BrowserRouter>
 	);
 };
 
 export default Router;
+/* 
+1. url에 유저 id 안 넣어도 됨? (안 넣어도 여전히 RESTful한 가?)
+
+users/:user_id/teams/:team_id/calendar
+users/:user_id/teams/:team_id/chats
+users/:user_id/teams/:team_id/chats/:chat_id
+*/

--- a/frontend/src/stores/team.ts
+++ b/frontend/src/stores/team.ts
@@ -1,20 +1,22 @@
 import { atom, selector } from 'recoil';
 import { readMyTeam } from '../apis/team';
-import UserState from './user';
 
 export const userInviteList = atom({
 	key: 'inviteList',
-	default: [],
+	default: [
+		{ team_id: 3, team_name: 'team#4', team_desc: 'team_desc#4' },
+		{ team_id: 4, team_name: 'team#5', team_desc: 'team_desc#5' },
+	],
 });
 
 export const userTeamList = selector({
 	key: 'teamList',
 	get: async ({ get }) => {
-		const user = get(UserState);
-		// 일단은 email로 찾는데, user_id가 있으면 좋을 듯?
-		const userEmail = user.email;
-		const response = await readMyTeam(userEmail);
+		// 기존 : recoil에 저장된 user 정보를 기반으로 요청
+		// 변경 : JWT 값으로 요청, user 구분은 서버에서 담당
+		const response = await readMyTeam();
 		const json = await response.json();
+		console.log(json);
 		return json;
 	},
 });

--- a/frontend/src/stores/team.ts
+++ b/frontend/src/stores/team.ts
@@ -4,19 +4,29 @@ import { readMyTeam } from '../apis/team';
 export const userInviteList = atom({
 	key: 'inviteList',
 	default: [
-		{ team_id: 3, team_name: 'team#4', team_desc: 'team_desc#4' },
-		{ team_id: 4, team_name: 'team#5', team_desc: 'team_desc#5' },
+		{
+			team_user_id: 1,
+			team: {
+				team_id: 3,
+				team_name: 'team#4',
+				team_desc: 'team_desc#4',
+			},
+		},
+		{
+			team_user_id: 2,
+			team: {
+				team_id: 4,
+				team_name: 'team#5',
+				team_desc: 'team_desc#5',
+			},
+		},
 	],
 });
 
 export const userTeamList = selector({
 	key: 'teamList',
-	get: async ({ get }) => {
-		// 기존 : recoil에 저장된 user 정보를 기반으로 요청
-		// 변경 : JWT 값으로 요청, user 구분은 서버에서 담당
-		const response = await readMyTeam();
-		const json = await response.json();
-		console.log(json);
-		return json;
+	get: async () => {
+		const teamList = await readMyTeam();
+		return teamList;
 	},
 });

--- a/frontend/src/stores/team.ts
+++ b/frontend/src/stores/team.ts
@@ -23,9 +23,15 @@ export const userInviteList = atom({
 	],
 });
 
+export const teamListLoadTrigger = atom({
+	key: 'loadTrigger',
+	default: 0,
+});
+
 export const userTeamList = selector({
 	key: 'teamList',
-	get: async () => {
+	get: async ({ get }) => {
+		get(teamListLoadTrigger);
 		const teamList = await readMyTeam();
 		return teamList;
 	},

--- a/frontend/src/templates/TeamTemplate/index.tsx
+++ b/frontend/src/templates/TeamTemplate/index.tsx
@@ -2,29 +2,20 @@ import React, { Suspense } from 'react';
 
 import { Header } from '../../components/common';
 import { CardList } from '../../components/Team';
-
 import { Layout } from './style';
 
-const myTeam = [
-	{ team_id: 0, team_name: 'team#1', team_desc: 'team_desc#1' },
-	{ team_id: 1, team_name: 'team#2', team_desc: 'team_desc#2' },
-	{ team_id: 2, team_name: 'team#3', team_desc: 'team_desc#3' },
-];
-
-const inviteTeam = [{ team_id: 3, team_name: 'team#4', team_desc: 'team_desc#4' }];
-
-const Team: React.FC = () => {
+const TeamTemplate: React.FC = () => {
 	return (
 		<Layout>
 			<Header />
 			<Suspense fallback={<div>loading</div>}>
-				<CardList dummy={myTeam} type='myTeam' />
+				<CardList type='myTeam' />
 			</Suspense>
 			<Suspense fallback={<div>loading</div>}>
-				<CardList dummy={inviteTeam} type='invitation' />
+				<CardList type='invitation' />
 			</Suspense>
 		</Layout>
 	);
 };
 
-export default Team;
+export default TeamTemplate;


### PR DESCRIPTION
## 작업 내용
- [X] 팀 목록 불러오기 구현 
- [X] 팀 선택 구현 
- [X] 팀 생성 구현 (API만)

## 주요 변경 사항
- 팀 목록 불러오기를 구현했습니다
- 초대 수락을 구현했습니다 (변경 예정)
- 초대 거절을 구현했습니다 (변경 예정)

## 구현 스크린샷 (선택)

## 궁금한점
1. 초대 목록을 어떻게 관리할지 고민입니다. 일단은 Team-User Table에 초대 데이터도 관리하기로 결정했습니다. (현재는 recoil에서 Dummy 데이터 사용중)
2. 팀이 삭제되면, 다른 데이터 (Team-User, Schedule, Chat rooms, postit)도 같이 삭제되면(cascade) 좋을 것 같은데 어떻게 생각하시나요? 

+a : 할 게 생각보다 많아서 오래걸릴 것 같습니다.... 따흐흑