### PR TITLE
[Feat/socket#65] 소켓 연결 설정, 팀 온라인 유저 배열 가져오기

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,7 +9,9 @@ import cors from 'cors';
 import passport from 'passport';
 import { initStrategy } from './passport';
 
-import SocketIO from './sockets';
+import { Namespace, Server } from 'socket.io';
+import socketInit from './sockets';
+
 import userRouter from './routes/user-router';
 import authRouter from './routes/auth-router';
 import scheduleRouter from './routes/schedule-router';
@@ -61,11 +63,12 @@ class App {
 		});
 
 		const corsOptions = {
-			cors: true,
-			origins: [process.env.FRONT_URL || 'http://localhost:3000']
+			cors: { origin: [process.env.FRONT_URL || 'http://localhost:3000'] }
 		};
 
-		SocketIO.attach(this.server, corsOptions);
+		const io: Server = new Server(this.server, corsOptions);
+		const namespace: Namespace = io.of(/^\/team-\d+$/);
+		socketInit(namespace);
 	}
 }
 

--- a/backend/src/sockets/index.ts
+++ b/backend/src/sockets/index.ts
@@ -1,54 +1,8 @@
-import { Socket } from 'socket.io';
+import { Namespace } from 'socket.io';
+import teamInit from './team';
 
-const io = require('socket.io');
-const socketIO = io();
+const socketInit = (namespace: Namespace): void => {
+	teamInit(namespace);
+};
 
-interface UserType {
-	userId: string;
-	socketId: string;
-	state: number;
-}
-
-// {team_id1: [{user_id, socket_id, state}], team_id2: [{user_id, socket_id, state}]}
-let userListByTeam = {};
-
-const userConnected = (teamId: number, userId: string): boolean => {
-	if(!userListByTeam[teamId]) return false;
-	return userListByTeam[teamId].filter((user: UserType) => user.userId === userId).length > 0;
-}
-
-socketIO.on('connect', (socket: Socket) => {
-	console.log('socket connect');
-
-	socket.on('check team join', ({teamId, userId}: {teamId: number, userId: string}) => {
-		socket.emit('check team join result', { teamId, userId, result: userConnected(teamId, userId) });
-	})
-
-	socket.on('join team', ({teamId, userId}: {teamId: number, userId: string}) => {
-		const socketId = socket.id;
-		const state = 0;
-		userListByTeam[teamId] ? userListByTeam[teamId].push({userId, socketId, state}) : userListByTeam[teamId] = [{userId, socketId, state}];
-		socket.join(teamId.toString());
-		console.log(userListByTeam)
-	})
-	socket.disconnect
-});
-
-/*
-최초 접속시 소켓 연결
-`const socket = io()`
-팀 유저 온라인 객체
-최초 {}
-형식 `{team_id1: [], team_id2: []}`
-
-팀 선택 페이지 -> 팀 id: 1 로 들어가면
-`socket.join(teamId)`
-팀 온라인 유저 배열에 유저 추가
-`arr.team_id1 ? arr.team_id = [{userId, state, socketId}] : arr.team_id.push({userId, state})`
-
-팀 선택 페이지로 나오거나 다른 팀으로 접속하거나 disconnect 시
-`socket.leave(teamId);`
-arr.team_id 배열에서 user 삭제
-*/
-
-export default socketIO;
+export default socketInit;

--- a/backend/src/sockets/index.ts
+++ b/backend/src/sockets/index.ts
@@ -3,8 +3,52 @@ import { Socket } from 'socket.io';
 const io = require('socket.io');
 const socketIO = io();
 
+interface UserType {
+	userId: string;
+	socketId: string;
+	state: number;
+}
+
+// {team_id1: [{user_id, socket_id, state}], team_id2: [{user_id, socket_id, state}]}
+let userListByTeam = {};
+
+const userConnected = (teamId: number, userId: string): boolean => {
+	if(!userListByTeam[teamId]) return false;
+	return userListByTeam[teamId].filter((user: UserType) => user.userId === userId).length > 0;
+}
+
 socketIO.on('connect', (socket: Socket) => {
 	console.log('socket connect');
+
+	socket.on('check team join', ({teamId, userId}: {teamId: number, userId: string}) => {
+		socket.emit('check team join result', { teamId, userId, result: userConnected(teamId, userId) });
+	})
+
+	socket.on('join team', ({teamId, userId}: {teamId: number, userId: string}) => {
+		const socketId = socket.id;
+		const state = 0;
+		userListByTeam[teamId] ? userListByTeam[teamId].push({userId, socketId, state}) : userListByTeam[teamId] = [{userId, socketId, state}];
+		socket.join(teamId.toString());
+		console.log(userListByTeam)
+	})
+	socket.disconnect
 });
+
+/*
+최초 접속시 소켓 연결
+`const socket = io()`
+팀 유저 온라인 객체
+최초 {}
+형식 `{team_id1: [], team_id2: []}`
+
+팀 선택 페이지 -> 팀 id: 1 로 들어가면
+`socket.join(teamId)`
+팀 온라인 유저 배열에 유저 추가
+`arr.team_id1 ? arr.team_id = [{userId, state, socketId}] : arr.team_id.push({userId, state})`
+
+팀 선택 페이지로 나오거나 다른 팀으로 접속하거나 disconnect 시
+`socket.leave(teamId);`
+arr.team_id 배열에서 user 삭제
+*/
 
 export default socketIO;

--- a/backend/src/sockets/store.ts
+++ b/backend/src/sockets/store.ts
@@ -1,0 +1,5 @@
+// {teamId1: [{userId}, {userId}], teamId2: [{userId}]}
+export const onlineUsersByTeam = {};
+
+// {socketId: {currTeamId, userId}, socketId: {currTeamId, userId}}
+export const onlineUsersInfo = {};

--- a/backend/src/sockets/team.ts
+++ b/backend/src/sockets/team.ts
@@ -1,0 +1,39 @@
+import { Namespace, Socket } from 'socket.io';
+import { onlineUsersByTeam, onlineUsersInfo } from './store';
+
+interface UserType {
+	userId: string;
+}
+
+const teamInit = (namespace: Namespace): void => {
+	const setUserStatusToOnline = (teamId: number, userId: string, socketId: string): void => {
+		if (!onlineUsersByTeam[teamId]) onlineUsersByTeam[teamId] = [{ userId }];
+		else {
+			const users = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
+			onlineUsersByTeam[teamId] = [...users, { userId }];
+		}
+		onlineUsersInfo[socketId] = { teamId, userId };
+	};
+
+	const setUserStatusToOffline = (socketId: string): void => {
+		const { teamId, userId } = onlineUsersInfo[socketId];
+		onlineUsersByTeam[teamId] = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
+		delete onlineUsersInfo[socketId];
+	};
+
+	namespace.on('connect', (socket: Socket) => {
+		console.log('socket connect', socket.id, socket.nsp.name);
+
+		socket.on('change status to online', ({ teamId, userId }: { teamId: number; userId: string }) => {
+			setUserStatusToOnline(teamId, userId, socket.id);
+			console.log('online', onlineUsersByTeam, onlineUsersInfo);
+		});
+
+		socket.on('disconnect', () => {
+			setUserStatusToOffline(socket.id);
+			console.log('offline', onlineUsersByTeam, onlineUsersInfo);
+		});
+	});
+};
+
+export default teamInit;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,21 +6,22 @@ import { ToastContainer } from 'react-toastify';
 import Router from './routes/router';
 import 'react-toastify/dist/ReactToastify.css';
 import LoadingPage from './pages/LoadingPage';
+import { SocketContext } from './utils/socketContext';
 
 dotenv.config();
 
 const App: React.FC = () => {
-	useEffect(() => {
-		const socket = socketIOClient(process.env.REACT_APP_SERVER || 'http://localhost:4000');
-		socket.connect();
-	}, []);
+	const socket = socketIOClient(process.env.REACT_APP_SERVER || 'http://localhost:4000');
+	socket.connect();
 
 	return (
 		<Suspense fallback={<LoadingPage />}>
-			<RecoilRoot>
-				<Router />
-			</RecoilRoot>
-			<ToastContainer />
+			<SocketContext.Provider value={socket}>
+				<RecoilRoot>
+					<Router />
+				</RecoilRoot>
+				<ToastContainer />
+			</SocketContext.Provider>
 		</Suspense>
 	);
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,20 @@
-import React, { Suspense, useEffect } from 'react';
-import socketIOClient from 'socket.io-client';
+import React, { Suspense } from 'react';
 import dotenv from 'dotenv';
 import { RecoilRoot } from 'recoil';
 import { ToastContainer } from 'react-toastify';
 import Router from './routes/router';
 import 'react-toastify/dist/ReactToastify.css';
 import LoadingPage from './pages/LoadingPage';
-import { SocketContext } from './utils/socketContext';
 
 dotenv.config();
 
 const App: React.FC = () => {
-	const socket = socketIOClient(process.env.REACT_APP_SERVER || 'http://localhost:4000');
-	socket.connect();
-
 	return (
 		<Suspense fallback={<LoadingPage />}>
-			<SocketContext.Provider value={socket}>
-				<RecoilRoot>
-					<Router />
-				</RecoilRoot>
-				<ToastContainer />
-			</SocketContext.Provider>
+			<RecoilRoot>
+				<Router />
+			</RecoilRoot>
+			<ToastContainer />
 		</Suspense>
 	);
 };

--- a/frontend/src/components/common/Navbar/index.tsx
+++ b/frontend/src/components/common/Navbar/index.tsx
@@ -30,7 +30,7 @@ const Navbar: React.FC = () => {
 				<Link to={`${path}/calendar`}>
 					<FaCalendarDay />
 				</Link>
-				<Link to={`${path}/setting`}>
+				<Link to={`${path}/users`}>
 					<FaUserFriends />
 				</Link>
 			</TabContainer>

--- a/frontend/src/pages/UsersPage/index.tsx
+++ b/frontend/src/pages/UsersPage/index.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useContext } from 'react';
+import UsersTemplate from '../../templates/UsersTemplate';
+import { SocketContext } from '../../utils/socketContext';
+
+const UsersPage: React.FC = () => {
+	const socketRef = useContext(SocketContext);
+	useEffect(() => {
+		socketRef.current.on('online users', (data: any) => {
+			console.log(data);
+		});
+		socketRef.current.emit('enter users room');
+		return () => {
+			socketRef.current.emit('leave users room');
+			socketRef.current.off('online users');
+		};
+	}, []);
+
+	return <UsersTemplate />;
+};
+
+export default UsersPage;

--- a/frontend/src/routes/PrivateRoute.tsx
+++ b/frontend/src/routes/PrivateRoute.tsx
@@ -1,15 +1,13 @@
-import React, { useContext, useEffect, useLayoutEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Redirect, Route } from 'react-router';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { check } from '../apis/auth';
 import UserState from '../stores/user';
 import { removeCookie } from '../utils/cookie';
-import { SocketContext } from '../utils/socketContext';
 
 const PrivateRoute = ({ component: Component, ...rest }: any) => {
-	const [user, setUser] = useRecoilState(UserState);
-	const socket = useContext(SocketContext);
-	useLayoutEffect(() => {
+	const setUser = useSetRecoilState(UserState);
+	useEffect(() => {
 		if (localStorage.getItem('JWT')) {
 			check(
 				(res: any) => {
@@ -26,18 +24,6 @@ const PrivateRoute = ({ component: Component, ...rest }: any) => {
 					removeCookie('JWT', '');
 				},
 			);
-		}
-	});
-	useEffect(() => {
-		if (true) {
-			socket.emit('check team join', { teamId: 1, userId: user.email });
-			socket.on('check team join result', (res: any) => {
-				if (res.result === ' true') {
-					console.log(true);
-				} else {
-					socket.emit('join team', { teamId: 1, userId: res.userId });
-				}
-			});
 		}
 	}, []);
 	return (

--- a/frontend/src/routes/PrivateRoute.tsx
+++ b/frontend/src/routes/PrivateRoute.tsx
@@ -1,13 +1,15 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect, useLayoutEffect } from 'react';
 import { Redirect, Route } from 'react-router';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { check } from '../apis/auth';
 import UserState from '../stores/user';
 import { removeCookie } from '../utils/cookie';
+import { SocketContext } from '../utils/socketContext';
 
 const PrivateRoute = ({ component: Component, ...rest }: any) => {
-	const setUser = useSetRecoilState(UserState);
-	useEffect(() => {
+	const [user, setUser] = useRecoilState(UserState);
+	const socket = useContext(SocketContext);
+	useLayoutEffect(() => {
 		if (localStorage.getItem('JWT')) {
 			check(
 				(res: any) => {
@@ -24,6 +26,18 @@ const PrivateRoute = ({ component: Component, ...rest }: any) => {
 					removeCookie('JWT', '');
 				},
 			);
+		}
+	});
+	useEffect(() => {
+		if (true) {
+			socket.emit('check team join', { teamId: 1, userId: user.email });
+			socket.on('check team join result', (res: any) => {
+				if (res.result === ' true') {
+					console.log(true);
+				} else {
+					socket.emit('join team', { teamId: 1, userId: res.userId });
+				}
+			});
 		}
 	}, []);
 	return (

--- a/frontend/src/routes/TeamRoute.tsx
+++ b/frontend/src/routes/TeamRoute.tsx
@@ -7,6 +7,7 @@ import UserState from '../stores/user';
 
 import ChatPage from '../pages/ChatPage';
 import CalendarPage from '../pages/CalendarPage';
+import UsersPage from '../pages/UsersPage';
 
 const TeamRoute = ({ computedMatch }: any) => {
 	const { teamId } = computedMatch.params;
@@ -25,6 +26,7 @@ const TeamRoute = ({ computedMatch }: any) => {
 		<SocketContext.Provider value={socketRef}>
 			<PrivateRoute exact path='/team/:teamId/chat' component={ChatPage} />
 			<PrivateRoute exact path='/team/:teamId/calendar' component={CalendarPage} />
+			<PrivateRoute exact path='/team/:teamId/users' component={UsersPage} />
 		</SocketContext.Provider>
 	);
 };

--- a/frontend/src/routes/TeamRoute.tsx
+++ b/frontend/src/routes/TeamRoute.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { useRecoilValue } from 'recoil';
+import PrivateRoute from './PrivateRoute';
+import { SocketContext } from '../utils/socketContext';
+import UserState from '../stores/user';
+
+import ChatPage from '../pages/ChatPage';
+import CalendarPage from '../pages/CalendarPage';
+
+const TeamRoute = ({ computedMatch }: any) => {
+	const { teamId } = computedMatch.params;
+	const userEmail = useRecoilValue(UserState).email;
+	const socketRef = useRef<Socket>();
+
+	useEffect(() => {
+		socketRef.current = io(`${process.env.REACT_APP_SERVER}/team-${teamId}` || `http://localhost:4000/team-${teamId}`);
+		socketRef.current.emit('change status to online', { teamId, userId: userEmail });
+		return () => {
+			socketRef.current?.disconnect();
+		};
+	}, [teamId]);
+
+	return (
+		<SocketContext.Provider value={socketRef}>
+			<PrivateRoute exact path='/team/:teamId/chat' component={ChatPage} />
+			<PrivateRoute exact path='/team/:teamId/calendar' component={CalendarPage} />
+		</SocketContext.Provider>
+	);
+};
+
+export default TeamRoute;

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import PrivateRoute from './PrivateRoute';
 import PublicRoute from './PublicRoute';
+import TeamRoute from './TeamRoute';
 
-import ChatPage from '../pages/ChatPage';
 import LoginPage from '../pages/LoginPage';
-import CalendarPage from '../pages/CalendarPage';
 import TeamPage from '../pages/TeamPage';
 import SignUpPage from '../pages/SignUpPage';
 import LoadingPage from '../pages/LoadingPage';
@@ -18,8 +17,7 @@ const Router: React.FC = () => {
 				<PublicRoute exact path='/' component={LoginPage} />
 				<PublicRoute exact path='/signup' component={SignUpPage} />
 				<PrivateRoute exact path='/team' component={TeamPage} />
-				<PrivateRoute exact path='/team/:teamId/chat' component={ChatPage} />
-				<PrivateRoute exact path='/team/:teamId/calendar' component={CalendarPage} />
+				<TeamRoute path='/team/:teamId' />
 				<Route exact path='/loading' component={LoadingPage} />
 				<Route path='*' component={ErrorPage} />
 			</Switch>

--- a/frontend/src/templates/UsersTemplate/index.tsx
+++ b/frontend/src/templates/UsersTemplate/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const UsersTemplate: React.FC = () => {
+	return <div>users</div>;
+};
+export default UsersTemplate;

--- a/frontend/src/utils/socketContext.ts
+++ b/frontend/src/utils/socketContext.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const SocketContext = React.createContext<any>(null);
+
+// if (true) {
+//     console.log('user email: ', res.user_email);
+//     socket.emit('check team join', { teamId: 1, userId: res.user_email });
+//     socket.on('check team join result', (res: any) => {
+//         console.log(res);
+//         if (res.result === ' true') {
+//             console.log(true);
+//         } else {
+//             socket.emit('join team', { teamId: 1, userId: res.userId});
+//         }
+//     });
+// }

--- a/frontend/src/utils/socketContext.ts
+++ b/frontend/src/utils/socketContext.ts
@@ -1,16 +1,3 @@
 import React from 'react';
 
 export const SocketContext = React.createContext<any>(null);
-
-// if (true) {
-//     console.log('user email: ', res.user_email);
-//     socket.emit('check team join', { teamId: 1, userId: res.user_email });
-//     socket.on('check team join result', (res: any) => {
-//         console.log(res);
-//         if (res.result === ' true') {
-//             console.log(true);
-//         } else {
-//             socket.emit('join team', { teamId: 1, userId: res.userId});
-//         }
-//     });
-// }


### PR DESCRIPTION
## 작업 내용
- [x] 소켓 연결 확인
- [x] 프론트 team route 생성
- [x] 팀별 온라인 유저 배열 생성
- [x] 팀 내부 관리 페이지 접속했을 때 배열 가져오기
- [x] 다른 사람이 접속, 접속 해제 했을 때 배열 가져오기

## 주요 변경 사항
[소켓 명세서](https://www.notion.so/af7060f3b2084df0be34d27933fb5154)

아래 내용도 노션 dev log에 적어두었습니다!

### 팀별 다이나믹 namespace 활용

server index.ts

```tsx
const io: Server = new Server(this.server, corsOptions);
const namespace: Namespace = io.of(/^\/team-\d+$/);
```

- 서버 실행할 때 다이나믹 namespace 생성
- 팀별로 해당 namespace에 소켓 접속한다.
- 팀을 변경할 경우 소켓 접속을 끊고 다른 namespace로 다시 접속하는 방식이다.
- namespace: `/team-teamId`
    - ex) `/team-1`

### `/team/:teamId` 일 때 소켓접속, 라우팅은 어떻게?

client routes/router.tsx

```tsx
const Router: React.FC = () => {
	return (
		<BrowserRouter>
			<Switch>
				<PublicRoute exact path='/' component={LoginPage} />
				<PublicRoute exact path='/signup' component={SignUpPage} />
				<PrivateRoute exact path='/team' component={TeamPage} />
				<TeamRoute path='/team/:teamId' />
				<Route exact path='/loading' component={LoadingPage} />
				<Route path='*' component={ErrorPage} />
			</Switch>
		</BrowserRouter>
	);
};
```

- TeamRoute 생성. `/team/:teamId` 일 때 TeamRoute로 보내기

### TeamRoute

client routes/TeamRoute.tsx

```tsx
const TeamRoute = ({ computedMatch }: any) => {
	const { teamId } = computedMatch.params;
	const userEmail = useRecoilValue(UserState).email;
	const socketRef = useRef<Socket>();

	useEffect(() => {
		socketRef.current = io(`${process.env.REACT_APP_SERVER}/team-${teamId}` || `http://localhost:4000/team-${teamId}`);
		socketRef.current.emit('change status to online', { teamId, userId: userEmail });
		return () => {
			socketRef.current?.disconnect();
		};
	}, [teamId]);

	return (
		<SocketContext.Provider value={socketRef}>
			<PrivateRoute exact path='/team/:teamId/chat' component={ChatPage} />
			<PrivateRoute exact path='/team/:teamId/calendar' component={CalendarPage} />
		</SocketContext.Provider>
	);
};
```

- param 에서 teamId를 가져온다. `const { teamId } = computedMatch.params;`
- 리코일에서 userEmail을 가져온다. `const userEmail = useRecoilValue(UserState).email;`
    - 여기서 문제..
        - **새로고침 했을 때는 리코일에 유저 이메일이 없어서 빈칸으로 가져와진다..**
        - **privateroute에서 유저 정보를 가져오는데 먼저 하던가 다른 조치가 필요**
- useEffect로 teamId에 변경이 일어날 때 소켓 접속을 다시한다.
    - ex) 나브바에서 팀을 변경했을 경우
- context api를 이용해 socket context를 전달한다.

### 유저 저장

server socket/store.ts

```tsx
// {teamId1: [{userId}, {userId}], teamId2: [{userId}]}
export const onlineUsersByTeam = {};

// {socketId: {currTeamId, userId}, socketId: {currTeamId, userId}}
export const onlineUsersInfo = {};
```

- onlineUsersByTeam 객체
    
    ```tsx
    {
        teamId1: [{userId}, {userId}],
        teamId2: [{userId}]
    }
    
    // ex
    {
        '19': [ { userId: 'test123@naver.com' } ],
        '34': [ { userId: '47925079' } ]
    }
    ```
    
    team별 온라인 유저id 객체 저장
    
    팀 관리 페이지에서 상태 가져올 때 이 정보를 가져오면 됩니다.
    
- onlineUsersInfo 객체
    
    ```tsx
    {
        socketId1: {currTeamId, userId},
        socketId2: {currTeamId, userId}
    }
    
    // ex
    {
        'OxQsI3Tq6QxZs0qUAAAD': { teamId: '19', userId: 'test123@naver.com' },
        'mlylKzXsK5bHI-10AAAG': { teamId: '34', userId: '47925079' }
    }
    ```
    
    온라인인 소켓id 별 teamId, userId 정보 저장
    

- 왜 분리하였나..?
    
    소켓이 disconnect 되었을 때 소켓 id만 가지고 userId를 찾아 team별 온라인 유저에서 삭제하여야 하는데, 만약 onlineUsersByTeam 에 소켓정보까지 저장해버리면 객체 전체를 탐색해야한다..

## 구현 스크린샷 (선택)
![Animation2](https://user-images.githubusercontent.com/47925079/141610064-659254fb-a43a-46e7-b50b-150625e0e596.gif)
편의상 스크린샷 페이지를 유저 a, 다른 유저를 b라 하겠습니다.
a를 팀 내부 관리 페이지에 접속해놓고 b는 팀 선택 페이지에서 팀으로 들어왔다 나갔다 하는 중입니다. 
console에 배열 찍히도록 해두었습니다~!

## 궁금한점
> team에서 팀 선택해서 접속하는 경우는 괜찮은데, 새로고침하거나 주소로 접속한 경우 리코일에 유저 이메일이 없어서 빈칸으로 가져와집니다. 현재 PrivateRoute에서 유저 정보를 가져오는데 이부분 순서 조정이 조금 필요할 것 같습니다! 좋은 아이디어 있으면 환영합니다..

> socket context 파일에서 `export const SocketContext = React.createContext<any>(null);` 이거 도대체 타입 뭘까요?

> 팀 내부 관리 페이지 네이밍을 현재 그냥 UsersPage로 해놨는데 더 좋은 이름이 있을까요? 네이밍 너무 어렵..😂