### PR TITLE
[Feat] 팀 내부관리 페이지 UI 구성

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,6 @@
     "@types/crypto-js": "^4.0.2",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",
-    "@types/react": "^17.0.33",
     "@types/react-datepicker": "^4.1.7",
     "@types/react-dom": "^17.0.10",
     "@types/react-router": "^5.1.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "@types/crypto-js": "^4.0.2",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",
+    "@types/react": "^17.0.33",
     "@types/react-datepicker": "^4.1.7",
     "@types/react-dom": "^17.0.10",
     "@types/react-router": "^5.1.17",

--- a/frontend/src/components/Users/SearchUsers/style.ts
+++ b/frontend/src/components/Users/SearchUsers/style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const HeaderText = styled.div`
+	font-size: 2rem;
+	font-weight: bold;
+`;
+
+export const InputContainer = styled.div`
+	width: 20%;
+	display: flex;
+	align-items: center;
+`;
+
+export const IconWrapper = styled.div`
+	position: relative;
+	left: -1.5rem;
+`;
+
+export const SearchInput = styled.input`
+	width: 100%;
+	padding: 0.5rem;
+`;

--- a/frontend/src/components/Users/UserList/SearchUsers.tsx
+++ b/frontend/src/components/Users/UserList/SearchUsers.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { FaSearch } from 'react-icons/fa';
+import { HeaderText, SearchInput, IconWrapper, InputContainer, Container } from './style';
+
+interface Props {
+	handleInput: (e: any) => void;
+}
+
+const SearchUsers: React.FC<Props> = ({ handleInput }) => {
+	return (
+		<Container>
+			<HeaderText>구성원</HeaderText>
+			<InputContainer>
+				<SearchInput type='text' placeholder='구성원 검색' onChange={handleInput} />
+				<IconWrapper>
+					<FaSearch />
+				</IconWrapper>
+			</InputContainer>
+		</Container>
+	);
+};
+
+export default SearchUsers;

--- a/frontend/src/components/Users/UserList/UserList.tsx
+++ b/frontend/src/components/Users/UserList/UserList.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { LabelContainer, UserWrapper, Container } from './style';
+
+interface Props {
+	users: any[];
+}
+
+const UsersList: React.FC<Props> = ({ users }) => {
+	const managerUsers = users.filter((e) => e.role === '관리자');
+	const normalUsers = users.filter((e) => e.role !== '관리자');
+	return (
+		<Container>
+			<div>소유자</div>
+			<LabelContainer>
+				<div>이름</div>
+				<div>역할</div>
+			</LabelContainer>
+			{managerUsers.map((e) => (
+				<UserWrapper>
+					<div>{e.name}</div>
+					<div>{e.role}</div>
+				</UserWrapper>
+			))}
+			<div>구성원</div>
+			<LabelContainer>
+				<div>이름</div>
+				<div>역할</div>
+			</LabelContainer>
+			{normalUsers.map((e) => (
+				<UserWrapper>
+					<div>{e.name}</div>
+					<div>{e.role}</div>
+				</UserWrapper>
+			))}
+		</Container>
+	);
+};
+
+export default UsersList;

--- a/frontend/src/components/Users/UserList/UserList.tsx
+++ b/frontend/src/components/Users/UserList/UserList.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'hoist-non-react-statics/node_modules/@types/react';
 import React from 'react';
 import { LabelContainer, UserWrapper, Container } from './style';
 
@@ -6,30 +7,34 @@ interface Props {
 }
 
 const UsersList: React.FC<Props> = ({ users }) => {
-	const managerUsers = users.filter((e) => e.role === '관리자');
-	const normalUsers = users.filter((e) => e.role !== '관리자');
+	const managerUsers: any[] = [];
+	const normalUsers: any[] = [];
+	users.forEach((e) => {
+		if (e.role === '관리자') managerUsers.push(e);
+		else normalUsers.push(e);
+	});
 	return (
 		<Container>
 			<div>소유자</div>
 			<LabelContainer>
-				<div>이름</div>
-				<div>역할</div>
+				<span>이름</span>
+				<span>역할</span>
 			</LabelContainer>
 			{managerUsers.map((e) => (
-				<UserWrapper>
-					<div>{e.name}</div>
-					<div>{e.role}</div>
+				<UserWrapper key={e.name}>
+					<span>{e.name}</span>
+					<span>{e.role}</span>
 				</UserWrapper>
 			))}
 			<div>구성원</div>
 			<LabelContainer>
-				<div>이름</div>
-				<div>역할</div>
+				<span>이름</span>
+				<span>역할</span>
 			</LabelContainer>
 			{normalUsers.map((e) => (
-				<UserWrapper>
-					<div>{e.name}</div>
-					<div>{e.role}</div>
+				<UserWrapper key={e.name}>
+					<span>{e.name}</span>
+					<span>{e.role}</span>
 				</UserWrapper>
 			))}
 		</Container>

--- a/frontend/src/components/Users/UserList/index.tsx
+++ b/frontend/src/components/Users/UserList/index.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import SearchUsers from '@components/Users/UserList/SearchUsers';
+import UserList from '@components/Users/UserList/UserList';
+import { UserListWrapper } from './style';
+
+const UsersTemplate: React.FC = () => {
+	const users = [
+		{
+			name: '강민지',
+			role: '관리자',
+		},
+		{
+			name: '이명재',
+			role: '구성원',
+		},
+		{
+			name: '이원주',
+			role: '구성원',
+		},
+		{
+			name: '장수용',
+			role: '구성원',
+		},
+	];
+
+	const [filteredUsers, setFilteredUsers] = useState(users);
+
+	const handleInput = (e: any) => {
+		e.preventDefault();
+		setFilteredUsers(users.filter((elem) => elem.name.indexOf(e.target.value) !== -1));
+	};
+	return (
+		<UserListWrapper>
+			<SearchUsers handleInput={handleInput} />
+			<UserList users={filteredUsers} />
+		</UserListWrapper>
+	);
+};
+export default UsersTemplate;

--- a/frontend/src/components/Users/UserList/index.tsx
+++ b/frontend/src/components/Users/UserList/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import SearchUsers from '@components/Users/UserList/SearchUsers';
 import UserList from '@components/Users/UserList/UserList';
-import { UserListWrapper } from './style';
+import { Layout } from './style';
 
 const UsersTemplate: React.FC = () => {
 	const users = [
@@ -30,10 +30,10 @@ const UsersTemplate: React.FC = () => {
 		setFilteredUsers(users.filter((elem) => elem.name.indexOf(e.target.value) !== -1));
 	};
 	return (
-		<UserListWrapper>
+		<Layout>
 			<SearchUsers handleInput={handleInput} />
 			<UserList users={filteredUsers} />
-		</UserListWrapper>
+		</Layout>
 	);
 };
 export default UsersTemplate;

--- a/frontend/src/components/Users/UserList/style.ts
+++ b/frontend/src/components/Users/UserList/style.ts
@@ -1,0 +1,62 @@
+import { ColorCode } from '@src/utils/constants';
+import styled from 'styled-components';
+
+export const UserHeaderContainer = styled.div`
+	display: flex;
+	align-items: center;
+	padding: 5%;
+	width: 100%;
+`;
+
+export const Teamname = styled.div`
+	font-size: 18;
+`;
+
+export const HeaderText = styled.div`
+	font-size: 2rem;
+	font-weight: bold;
+`;
+
+export const InputContainer = styled.div`
+	width: 20%;
+	display: flex;
+	align-items: center;
+`;
+
+export const IconWrapper = styled.div`
+	position: relative;
+	left: -1.5rem;
+`;
+
+export const SearchInput = styled.input`
+	width: 100%;
+	padding: 0.5rem;
+	border-radius: 8px;
+	border: 1px solid ${ColorCode.BACKGROUND2};
+`;
+
+export const LabelContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+	margin: 1rem;
+`;
+
+export const UserWrapper = styled.div`
+	background-color: ${ColorCode.WHITE};
+	display: flex;
+	justify-content: space-between;
+	padding: 1rem;
+`;
+
+export const Container = styled.div`
+	& > * {
+		margin: 2rem;
+	}
+`;
+
+export const UserListWrapper = styled.div`
+	padding: 0 5% 5% 5%;
+	& > * {
+		margin: 1rem;
+	}
+`;

--- a/frontend/src/components/Users/UserList/style.ts
+++ b/frontend/src/components/Users/UserList/style.ts
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 export const UserHeaderContainer = styled.div`
 	display: flex;
 	align-items: center;
-	padding: 5%;
 	width: 100%;
 `;
 
@@ -13,7 +12,7 @@ export const Teamname = styled.div`
 `;
 
 export const HeaderText = styled.div`
-	font-size: 2rem;
+	font-size: 1.5rem;
 	font-weight: bold;
 `;
 
@@ -33,12 +32,13 @@ export const SearchInput = styled.input`
 	padding: 0.5rem;
 	border-radius: 8px;
 	border: 1px solid ${ColorCode.BACKGROUND2};
+	box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.1);
 `;
 
 export const LabelContainer = styled.div`
 	display: flex;
 	justify-content: space-between;
-	margin: 1rem;
+	padding: 0 1rem;
 `;
 
 export const UserWrapper = styled.div`
@@ -46,17 +46,16 @@ export const UserWrapper = styled.div`
 	display: flex;
 	justify-content: space-between;
 	padding: 1rem;
+	border-radius: 8px;
+	box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.1);
 `;
 
 export const Container = styled.div`
 	& > * {
-		margin: 2rem;
+		margin: 1.5rem 0;
 	}
 `;
 
 export const UserListWrapper = styled.div`
-	padding: 0 5% 5% 5%;
-	& > * {
-		margin: 1rem;
-	}
+	padding: 0 3% 3% 3%;
 `;

--- a/frontend/src/components/Users/UserList/style.ts
+++ b/frontend/src/components/Users/UserList/style.ts
@@ -1,16 +1,6 @@
 import { ColorCode } from '@src/utils/constants';
 import styled from 'styled-components';
 
-export const UserHeaderContainer = styled.div`
-	display: flex;
-	align-items: center;
-	width: 100%;
-`;
-
-export const Teamname = styled.div`
-	font-size: 18;
-`;
-
 export const HeaderText = styled.div`
 	font-size: 1.5rem;
 	font-weight: bold;
@@ -56,6 +46,6 @@ export const Container = styled.div`
 	}
 `;
 
-export const UserListWrapper = styled.div`
+export const Layout = styled.div`
 	padding: 0 3% 3% 3%;
 `;

--- a/frontend/src/components/Users/UsersHeader/index.tsx
+++ b/frontend/src/components/Users/UsersHeader/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Thumbnail from '@components/Team/Cards/Thumbnail';
-import { UserHeaderContainer, Teamname } from './style';
+import { UserHeaderContainer, TeamName } from './style';
 
 interface Props {
 	teamInfo: any;
@@ -10,7 +10,7 @@ const UsersHeader: React.FC<Props> = ({ teamInfo }) => {
 	return (
 		<UserHeaderContainer>
 			<Thumbnail team_id={teamInfo.teamId} team_name={teamInfo.teamName} />
-			<Teamname>{teamInfo.teamName}</Teamname>
+			<TeamName>{teamInfo.teamName}</TeamName>
 		</UserHeaderContainer>
 	);
 };

--- a/frontend/src/components/Users/UsersHeader/index.tsx
+++ b/frontend/src/components/Users/UsersHeader/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Thumbnail from '@components/Team/Cards/Thumbnail';
+import { UserHeaderContainer, Teamname } from './style';
+
+interface Props {
+	teamInfo: any;
+}
+
+const UsersHeader: React.FC<Props> = ({ teamInfo }) => {
+	return (
+		<UserHeaderContainer>
+			<Thumbnail team_id={teamInfo.teamId} team_name={teamInfo.teamName} />
+			<Teamname>{teamInfo.teamName}</Teamname>
+		</UserHeaderContainer>
+	);
+};
+
+export default UsersHeader;

--- a/frontend/src/components/Users/UsersHeader/style.ts
+++ b/frontend/src/components/Users/UsersHeader/style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const UserHeaderContainer = styled.div`
 	display: flex;
 	align-items: center;
-	padding: 5%;
+	padding: 2% 5%;
 `;
 
 export const Teamname = styled.div`

--- a/frontend/src/components/Users/UsersHeader/style.ts
+++ b/frontend/src/components/Users/UsersHeader/style.ts
@@ -6,7 +6,7 @@ export const UserHeaderContainer = styled.div`
 	padding: 2% 5%;
 `;
 
-export const Teamname = styled.div`
+export const TeamName = styled.div`
 	font-size: 1.5rem;
 	font-weight: bold;
 	margin: 0 5%;

--- a/frontend/src/components/Users/UsersHeader/style.ts
+++ b/frontend/src/components/Users/UsersHeader/style.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const UserHeaderContainer = styled.div`
+	display: flex;
+	align-items: center;
+	padding: 5%;
+`;
+
+export const Teamname = styled.div`
+	font-size: 1.5rem;
+	font-weight: bold;
+	margin: 0 5%;
+`;

--- a/frontend/src/pages/UsersPage/index.tsx
+++ b/frontend/src/pages/UsersPage/index.tsx
@@ -4,16 +4,16 @@ import { SocketContext } from '@utils/socketContext';
 
 const UsersPage: React.FC = () => {
 	const socketRef = useContext(SocketContext);
-	useEffect(() => {
-		socketRef.current.on('online users', (data: any) => {
-			console.log(data);
-		});
-		socketRef.current.emit('enter users room');
-		return () => {
-			socketRef.current.emit('leave users room');
-			socketRef.current.off('online users');
-		};
-	}, []);
+	// useEffect(() => {
+	// 	socketRef.current.on('online users', (data: any) => {
+	// 		console.log(data);
+	// 	});
+	// 	socketRef.current.emit('enter users room');
+	// 	return () => {
+	// 		socketRef.current.emit('leave users room');
+	// 		socketRef.current.off('online users');
+	// 	};
+	// }, []);
 
 	return <UsersTemplate />;
 };

--- a/frontend/src/templates/UsersTemplate/index.tsx
+++ b/frontend/src/templates/UsersTemplate/index.tsx
@@ -1,6 +1,27 @@
 import React from 'react';
+import { Header, Navbar, Sidebar } from '@components/common';
+import UsersHeader from '@components/Users/UsersHeader';
+import Users from '@src/components/Users/UserList';
+import { MainContainer, ContentContainer } from './style';
 
 const UsersTemplate: React.FC = () => {
-	return <div>users</div>;
+	const teamInfo = {
+		teamId: 1,
+		teamName: 'boostcamp web-29',
+		teamDesc: '팀 성명 정보입니다.',
+	};
+	return (
+		<div>
+			<Header />
+			<MainContainer>
+				<Navbar />
+				<Sidebar />
+				<ContentContainer>
+					<UsersHeader teamInfo={teamInfo} />
+					<Users />
+				</ContentContainer>
+			</MainContainer>
+		</div>
+	);
 };
 export default UsersTemplate;

--- a/frontend/src/templates/UsersTemplate/index.tsx
+++ b/frontend/src/templates/UsersTemplate/index.tsx
@@ -11,17 +11,16 @@ const UsersTemplate: React.FC = () => {
 		teamDesc: '팀 성명 정보입니다.',
 	};
 	return (
-		<div>
+		<>
 			<Header />
 			<MainContainer>
 				<Navbar />
-				<Sidebar />
 				<ContentContainer>
 					<UsersHeader teamInfo={teamInfo} />
 					<Users />
 				</ContentContainer>
 			</MainContainer>
-		</div>
+		</>
 	);
 };
 export default UsersTemplate;

--- a/frontend/src/templates/UsersTemplate/style.ts
+++ b/frontend/src/templates/UsersTemplate/style.ts
@@ -1,0 +1,16 @@
+import { ColorCode } from '@src/utils/constants';
+import styled from 'styled-components';
+
+export const MainContainer = styled.div`
+	position: absolute;
+	top: 3rem;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+`;
+
+export const ContentContainer = styled.div`
+	width: 100%;
+	background-color: ${ColorCode.BACKGROUND2};
+`;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3108,7 +3108,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.33":
+"@types/react@*":
   version "17.0.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
   integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3117,6 +3117,15 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/react@^17.0.33":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.35.tgz#217164cf830267d56cd1aec09dcf25a541eedd4c"
+  integrity sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"


### PR DESCRIPTION
## 작업 내용
- [x] 팀 내부관리 페이지 UI 구성

## 주요 변경 사항
팀 내부관리 UI를 구성하였습니다. 간단한 기능이라 input에 이름을 치면 구성원 검색이 되도록 구현해놨습니다.
구성원 리스트를 inputbar와 유저 리스트를 감싸는 컴포넌트에서 관리를 하게 해놔서 유저 정보에 변경이 있어도 그 부분만 재렌더링 되도록 하였습니다. 옆의 sidebar는 처음에 제가 만든건데 css 빨리 만져야겠네요..ㅋㅋㅋ 내일 수정하도록 하겠습니다.

p.s 일단 더미데이터 넣어놨습니다.

## 구현 스크린샷 (선택)
![image](https://user-images.githubusercontent.com/70019911/141778993-0c6e4df4-0aea-43c8-81ab-fde866051e75.png)
![image](https://user-images.githubusercontent.com/70019911/141779018-aa72940e-f9fc-40f6-a023-71cf3cf7f433.png)


## 궁금한점
1. 드롭다운 컴포넌트가 있던데 재사용할 수 있는지, 어떻게 사용하면 되는지 궁금합니다.
2. `frontend/src/pages/UsersPage/index.tsx `에서 socket.on이 에러나서 일단 주석 처리해 뒀는데 뭐가 문제인지 모르겠네요...흑흑
3. 스크린 사이즈를 바꿔보니 navbar 포함해서 문제가 있는데 내일 고쳐야할 것 같습니다.