### PR TITLE
[Feat] 팀, 유저 정보 가져오기, 팀 탈퇴 기능 구현

### DIFF
--- a/backend/src/controllers/team-contorller.ts
+++ b/backend/src/controllers/team-contorller.ts
@@ -14,6 +14,24 @@ const TeamController = {
 		}
 	},
 
+	async readTeamInfo(req: any, res: Response) {
+		try {
+			const team = await TeamService.getInstance().read(req.params.id);
+			res.status(200).send(team);
+		} catch (err) {
+			res.status(404).send(err);
+		}
+	},
+
+	async readTeamUsers(req: any, res: Response) {
+		try {
+			const teams = await TeamUserService.getInstance().readAllUsers(req.params.id);
+			res.status(200).send(teams);
+		} catch (err) {
+			res.status(404).send(err);
+		}
+	},
+
 	async create(req: any, res: Response) {
 		try {
 			const userId = req.user_id;
@@ -71,6 +89,7 @@ const TeamController = {
 		try {
 			const userId = req.user_id;
 			const teamId = req.body.team_id;
+			console.log(userId, teamId)
 			await TeamUserService.getInstance().delete(userId, teamId);
 			res.sendStatus(204);
 		} catch (err) {

--- a/backend/src/entities/team-user.ts
+++ b/backend/src/entities/team-user.ts
@@ -21,4 +21,7 @@ export class TeamUser {
 
 	@Column()
 	state: boolean;
+
+	@Column()
+	role: number;
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import userRouter from '@routes/user-router';
 import authRouter from '@routes/auth-router';
 import scheduleRouter from '@routes/schedule-router';
 import teamRouter from '@routes/team-router';
+import usersRouter from '@routes/users-router';
 
 class App {
 	app: express.Application;
@@ -55,6 +56,7 @@ class App {
 		this.app.use('/api/auth', authRouter);
 		this.app.use('/api/schedule', scheduleRouter);
 		this.app.use('/api/team', teamRouter);
+		this.app.use('/api/users', usersRouter);
 	}
 
 	listen() {

--- a/backend/src/routes/users-router.ts
+++ b/backend/src/routes/users-router.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import TeamController from '@controllers/team-contorller';
+import { authenticateToken } from '@middlewares/token';
+
+const router = express.Router();
+
+router.get('/team/:id', authenticateToken, TeamController.readTeamInfo);
+router.get('/:id', authenticateToken, TeamController.readTeamUsers);
+
+export default router;

--- a/backend/src/services/team-service.ts
+++ b/backend/src/services/team-service.ts
@@ -26,8 +26,9 @@ export default class TeamService {
 		return insertResult.raw.insertId;
 	}
 
-	async read(teamId: number) {
-		return await this.teamRepository.createQueryBuilder('team').where('team_id=:id', { id: teamId });
+	async read(team_id: number) {
+		const result = await this.teamRepository.find({where: {team_id}})
+		return result;
 	}
 
 	async update(teamData: TeamData) {

--- a/backend/src/services/team-user-service.ts
+++ b/backend/src/services/team-user-service.ts
@@ -37,6 +37,14 @@ export default class TeamUserService {
 			.getMany();
 	}
 
+	async readAllUsers(teamId: number) {
+		return await this.teamUserRepository
+			.createQueryBuilder('team_user')
+			.leftJoinAndSelect('team_user.user', 'user')
+			.where('team_user.team = :teamId', { teamId })
+			.getMany();
+	}
+
 	async update(userId: number, teamId: number) {
 		await this.teamUserRepository
 			.createQueryBuilder()

--- a/backend/src/sockets/team.ts
+++ b/backend/src/sockets/team.ts
@@ -6,55 +6,55 @@ interface UserType {
 }
 
 const teamInit = (namespace: Namespace): void => {
-	const setUserStatusToOnline = (teamId: number, userId: string, socketId: string): void => {
-		if (!onlineUsersByTeam[teamId]) onlineUsersByTeam[teamId] = [{ userId }];
-		else {
-			const users = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
-			onlineUsersByTeam[teamId] = [...users, { userId }];
-		}
-		onlineUsersInfo[socketId] = { teamId, userId };
-	};
+	// const setUserStatusToOnline = (teamId: number, userId: string, socketId: string): void => {
+	// 	if (!onlineUsersByTeam[teamId]) onlineUsersByTeam[teamId] = [{ userId }];
+	// 	else {
+	// 		const users = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
+	// 		onlineUsersByTeam[teamId] = [...users, { userId }];
+	// 	}
+	// 	onlineUsersInfo[socketId] = { teamId, userId };
+	// };
 
-	const setUserStatusToOffline = (teamId: number, userId: string, socketId: string): void => {
-		onlineUsersByTeam[teamId] = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
-		delete onlineUsersInfo[socketId];
-	};
+	// const setUserStatusToOffline = (teamId: number, userId: string, socketId: string): void => {
+	// 	onlineUsersByTeam[teamId] = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
+	// 	delete onlineUsersInfo[socketId];
+	// };
 
-	const sendOnlineUsers = (socket: Socket, teamId: number): void => {
-		socket.emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
-	};
+	// const sendOnlineUsers = (socket: Socket, teamId: number): void => {
+	// 	socket.emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
+	// };
 
-	const sendOnlineUsersToRoom = (socket: Socket, teamId: number): void => {
-		socket.to('users').emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
-	};
+	// const sendOnlineUsersToRoom = (socket: Socket, teamId: number): void => {
+	// 	socket.to('users').emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
+	// };
 
-	namespace.on('connect', (socket: Socket) => {
-		console.log('socket connect', socket.id, socket.nsp.name);
+	// namespace.on('connect', (socket: Socket) => {
+	// 	console.log('socket connect', socket.id, socket.nsp.name);
 
-		socket.on('change status to online', ({ teamId, userId }: { teamId: number; userId: string }) => {
-			setUserStatusToOnline(teamId, userId, socket.id);
-			sendOnlineUsersToRoom(socket, teamId);
-			// console.log('online', onlineUsersByTeam, onlineUsersInfo);
-		});
+	// 	socket.on('change status to online', ({ teamId, userId }: { teamId: number; userId: string }) => {
+	// 		setUserStatusToOnline(teamId, userId, socket.id);
+	// 		sendOnlineUsersToRoom(socket, teamId);
+	// 		// console.log('online', onlineUsersByTeam, onlineUsersInfo);
+	// 	});
 
-		socket.on('enter users room', () => {
-			const { teamId } = onlineUsersInfo[socket.id];
-			socket.join('users');
-			sendOnlineUsers(socket, teamId);
-			console.log('join users');
-		});
+	// 	socket.on('enter users room', () => {
+	// 		const { teamId } = onlineUsersInfo[socket.id];
+	// 		socket.join('users');
+	// 		sendOnlineUsers(socket, teamId);
+	// 		console.log('join users');
+	// 	});
 
-		socket.on('leave users room', () => {
-			socket.leave('users');
-		});
+	// 	socket.on('leave users room', () => {
+	// 		socket.leave('users');
+	// 	});
 
-		socket.on('disconnect', () => {
-			const { teamId, userId } = onlineUsersInfo[socket.id];
-			setUserStatusToOffline(teamId, userId, socket.id);
-			sendOnlineUsersToRoom(socket, teamId);
-			// console.log('offline', onlineUsersByTeam, onlineUsersInfo);
-		});
-	});
+	// 	socket.on('disconnect', () => {
+	// 		const { teamId, userId } = onlineUsersInfo[socket.id];
+	// 		setUserStatusToOffline(teamId, userId, socket.id);
+	// 		sendOnlineUsersToRoom(socket, teamId);
+	// 		// console.log('offline', onlineUsersByTeam, onlineUsersInfo);
+	// 	});
+	// });
 };
 
 export default teamInit;

--- a/backend/src/sockets/team.ts
+++ b/backend/src/sockets/team.ts
@@ -6,55 +6,55 @@ interface UserType {
 }
 
 const teamInit = (namespace: Namespace): void => {
-	// const setUserStatusToOnline = (teamId: number, userId: string, socketId: string): void => {
-	// 	if (!onlineUsersByTeam[teamId]) onlineUsersByTeam[teamId] = [{ userId }];
-	// 	else {
-	// 		const users = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
-	// 		onlineUsersByTeam[teamId] = [...users, { userId }];
-	// 	}
-	// 	onlineUsersInfo[socketId] = { teamId, userId };
-	// };
+	const setUserStatusToOnline = (teamId: number, userId: string, socketId: string): void => {
+		if (!onlineUsersByTeam[teamId]) onlineUsersByTeam[teamId] = [{ userId }];
+		else {
+			const users = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
+			onlineUsersByTeam[teamId] = [...users, { userId }];
+		}
+		onlineUsersInfo[socketId] = { teamId, userId };
+	};
 
-	// const setUserStatusToOffline = (teamId: number, userId: string, socketId: string): void => {
-	// 	onlineUsersByTeam[teamId] = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
-	// 	delete onlineUsersInfo[socketId];
-	// };
+	const setUserStatusToOffline = (teamId: number, userId: string, socketId: string): void => {
+		onlineUsersByTeam[teamId] = onlineUsersByTeam[teamId].filter((user: UserType) => user.userId !== userId);
+		delete onlineUsersInfo[socketId];
+	};
 
-	// const sendOnlineUsers = (socket: Socket, teamId: number): void => {
-	// 	socket.emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
-	// };
+	const sendOnlineUsers = (socket: Socket, teamId: number): void => {
+		socket.emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
+	};
 
-	// const sendOnlineUsersToRoom = (socket: Socket, teamId: number): void => {
-	// 	socket.to('users').emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
-	// };
+	const sendOnlineUsersToRoom = (socket: Socket, teamId: number): void => {
+		socket.to('users').emit('online users', { onlineUsers: onlineUsersByTeam[teamId] });
+	};
 
-	// namespace.on('connect', (socket: Socket) => {
-	// 	console.log('socket connect', socket.id, socket.nsp.name);
+	namespace.on('connect', (socket: Socket) => {
+		console.log('socket connect', socket.id, socket.nsp.name);
 
-	// 	socket.on('change status to online', ({ teamId, userId }: { teamId: number; userId: string }) => {
-	// 		setUserStatusToOnline(teamId, userId, socket.id);
-	// 		sendOnlineUsersToRoom(socket, teamId);
-	// 		// console.log('online', onlineUsersByTeam, onlineUsersInfo);
-	// 	});
+		socket.on('change status to online', ({ teamId, userId }: { teamId: number; userId: string }) => {
+			setUserStatusToOnline(teamId, userId, socket.id);
+			sendOnlineUsersToRoom(socket, teamId);
+			// console.log('online', onlineUsersByTeam, onlineUsersInfo);
+		});
 
-	// 	socket.on('enter users room', () => {
-	// 		const { teamId } = onlineUsersInfo[socket.id];
-	// 		socket.join('users');
-	// 		sendOnlineUsers(socket, teamId);
-	// 		console.log('join users');
-	// 	});
+		socket.on('enter users room', () => {
+			const { teamId } = onlineUsersInfo[socket.id];
+			socket.join('users');
+			sendOnlineUsers(socket, teamId);
+			console.log('join users');
+		});
 
-	// 	socket.on('leave users room', () => {
-	// 		socket.leave('users');
-	// 	});
+		socket.on('leave users room', () => {
+			socket.leave('users');
+		});
 
-	// 	socket.on('disconnect', () => {
-	// 		const { teamId, userId } = onlineUsersInfo[socket.id];
-	// 		setUserStatusToOffline(teamId, userId, socket.id);
-	// 		sendOnlineUsersToRoom(socket, teamId);
-	// 		// console.log('offline', onlineUsersByTeam, onlineUsersInfo);
-	// 	});
-	// });
+		socket.on('disconnect', () => {
+			const { teamId, userId } = onlineUsersInfo[socket.id];
+			setUserStatusToOffline(teamId, userId, socket.id);
+			sendOnlineUsersToRoom(socket, teamId);
+			// console.log('offline', onlineUsersByTeam, onlineUsersInfo);
+		});
+	});
 };
 
 export default teamInit;

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -25,3 +25,7 @@ export const decline = async (setLoadTrigger: (param: any) => void, team_id: num
 	await fetchApi.delete('/api/team/invite/response', { team_id });
 	setLoadTrigger((prev: number) => prev + 1);
 };
+
+export const leaveTeam = async (team_id: number) => {
+	await fetchApi.delete('/api/team/invite/response', { team_id });
+};

--- a/frontend/src/apis/users.ts
+++ b/frontend/src/apis/users.ts
@@ -1,0 +1,13 @@
+import fetchApi from '@utils/fetch';
+
+export const readTeamInfo = async (id: number) => {
+	const res = await fetchApi.get(`/api/users/team/${id}`);
+	const data = await res.json();
+	return data[0];
+};
+
+export const readTeamUsers = async (id: number) => {
+	const res = await fetchApi.get(`/api/users/${id}`);
+	const data = await res.json();
+	return data;
+};

--- a/frontend/src/components/Team/Cards/Thumbnail.tsx
+++ b/frontend/src/components/Team/Cards/Thumbnail.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 const Thumbnail: React.FC<Props> = ({ team_id, team_name }) => {
-	const shortenName = team_name.slice(0, 1).toUpperCase();
+	const shortenName = team_name?.slice(0, 1).toUpperCase();
 	return (
 		<ThumbnailWrapper team_id={team_id}>
 			<span>{shortenName}</span>

--- a/frontend/src/components/Users/UserList/SearchUsers.tsx
+++ b/frontend/src/components/Users/UserList/SearchUsers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FaSearch } from 'react-icons/fa';
-import { HeaderText, SearchInput, IconWrapper, InputContainer, Container } from './style';
+import { HeaderText, SearchInput, IconWrapper, InputContainer, Container, ExitBtn } from './style';
 
 interface Props {
 	handleInput: (e: any) => void;
@@ -16,9 +16,9 @@ const SearchUsers: React.FC<Props> = ({ handleInput, handleModalOpen }) => {
 				<IconWrapper>
 					<FaSearch />
 				</IconWrapper>
-				<button type='button' onClick={handleModalOpen}>
+				<ExitBtn type='button' onClick={handleModalOpen}>
 					팀 나가기
-				</button>
+				</ExitBtn>
 			</InputContainer>
 		</Container>
 	);

--- a/frontend/src/components/Users/UserList/SearchUsers.tsx
+++ b/frontend/src/components/Users/UserList/SearchUsers.tsx
@@ -4,9 +4,10 @@ import { HeaderText, SearchInput, IconWrapper, InputContainer, Container } from 
 
 interface Props {
 	handleInput: (e: any) => void;
+	handleModalOpen: () => void;
 }
 
-const SearchUsers: React.FC<Props> = ({ handleInput }) => {
+const SearchUsers: React.FC<Props> = ({ handleInput, handleModalOpen }) => {
 	return (
 		<Container>
 			<HeaderText>구성원</HeaderText>
@@ -15,6 +16,9 @@ const SearchUsers: React.FC<Props> = ({ handleInput }) => {
 				<IconWrapper>
 					<FaSearch />
 				</IconWrapper>
+				<button type='button' onClick={handleModalOpen}>
+					팀 나가기
+				</button>
 			</InputContainer>
 		</Container>
 	);

--- a/frontend/src/components/Users/UserList/UserList.tsx
+++ b/frontend/src/components/Users/UserList/UserList.tsx
@@ -20,8 +20,11 @@ const UsersList: React.FC<Props> = ({ users }) => {
 				<span>역할</span>
 			</LabelContainer>
 			{managerUsers.map((e) => (
-				<UserWrapper key={e.name}>
-					<span>{e.name}</span>
+				<UserWrapper key={e.id}>
+					<span>
+						<span>{e.state}</span>
+						<span>{e.name}</span>
+					</span>
 					<span>{e.role}</span>
 				</UserWrapper>
 			))}
@@ -31,8 +34,11 @@ const UsersList: React.FC<Props> = ({ users }) => {
 				<span>역할</span>
 			</LabelContainer>
 			{normalUsers.map((e) => (
-				<UserWrapper key={e.name}>
-					<span>{e.name}</span>
+				<UserWrapper key={e.id}>
+					<span>
+						<span>{e.state}</span>
+						<span>{e.name}</span>
+					</span>
 					<span>{e.role}</span>
 				</UserWrapper>
 			))}

--- a/frontend/src/components/Users/UserList/index.tsx
+++ b/frontend/src/components/Users/UserList/index.tsx
@@ -22,9 +22,9 @@ const UsersTemplate: React.FC<Props> = ({ teamId, handleModalOpen }) => {
 	const getUsers = async () => {
 		const result = await readTeamUsers(teamId);
 		const resultArr: any = [];
-		result.forEach((e: any) => {
-			resultArr.push({ id: e.user.user_id, name: e.user.user_name, state: e.user.user_state });
-		});
+		result.forEach((e: any) =>
+			resultArr.push({ id: e.user.user_id, name: e.user.user_name, state: e.user.user_state }),
+		);
 		setUsers(resultArr);
 		setFilteredUsers(resultArr);
 	};

--- a/frontend/src/components/Users/UserList/index.tsx
+++ b/frontend/src/components/Users/UserList/index.tsx
@@ -1,37 +1,47 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SearchUsers from '@components/Users/UserList/SearchUsers';
 import UserList from '@components/Users/UserList/UserList';
+import { readTeamUsers } from '@apis/users';
 import { Layout } from './style';
 
-const UsersTemplate: React.FC = () => {
-	const users = [
-		{
-			name: '강민지',
-			role: '관리자',
-		},
-		{
-			name: '이명재',
-			role: '구성원',
-		},
-		{
-			name: '이원주',
-			role: '구성원',
-		},
-		{
-			name: '장수용',
-			role: '구성원',
-		},
-	];
+interface Props {
+	teamId: number;
+	handleModalOpen: () => void;
+}
 
+interface User {
+	id: number;
+	name: string;
+	state: number;
+}
+
+const UsersTemplate: React.FC<Props> = ({ teamId, handleModalOpen }) => {
+	const [users, setUsers] = useState<User[]>([]);
 	const [filteredUsers, setFilteredUsers] = useState(users);
+
+	const getUsers = async () => {
+		const result = await readTeamUsers(teamId);
+		const resultArr: any = [];
+		result.forEach((e: any) => {
+			resultArr.push({ id: e.user.user_id, name: e.user.user_name, state: e.user.user_state });
+		});
+		setUsers(resultArr);
+		setFilteredUsers(resultArr);
+	};
+
+	useEffect(() => {
+		getUsers();
+	}, []);
 
 	const handleInput = (e: any) => {
 		e.preventDefault();
-		setFilteredUsers(users.filter((elem) => elem.name.indexOf(e.target.value) !== -1));
+		setFilteredUsers(
+			users.filter((elem: User) => elem.name.toLowerCase().indexOf(e.target.value.toLowerCase()) !== -1),
+		);
 	};
 	return (
 		<Layout>
-			<SearchUsers handleInput={handleInput} />
+			<SearchUsers handleInput={handleInput} handleModalOpen={handleModalOpen} />
 			<UserList users={filteredUsers} />
 		</Layout>
 	);

--- a/frontend/src/components/Users/UserList/style.ts
+++ b/frontend/src/components/Users/UserList/style.ts
@@ -49,3 +49,11 @@ export const Container = styled.div`
 export const Layout = styled.div`
 	padding: 0 3% 3% 3%;
 `;
+
+export const ExitBtn = styled.button`
+	padding: 2% 4%;
+	width: 10rem;
+	background-color: ${ColorCode.PRIMARY1};
+	color: ${ColorCode.WHITE};
+	border-radius: 8px;
+`;

--- a/frontend/src/components/Users/UsersHeader/index.tsx
+++ b/frontend/src/components/Users/UsersHeader/index.tsx
@@ -9,8 +9,8 @@ interface Props {
 const UsersHeader: React.FC<Props> = ({ teamInfo }) => {
 	return (
 		<UserHeaderContainer>
-			<Thumbnail team_id={teamInfo.teamId} team_name={teamInfo.teamName} />
-			<TeamName>{teamInfo.teamName}</TeamName>
+			<Thumbnail team_id={teamInfo?.team_id} team_name={teamInfo?.team_name} />
+			<TeamName>{teamInfo?.team_name}</TeamName>
 		</UserHeaderContainer>
 	);
 };

--- a/frontend/src/components/Users/UsersModal/index.tsx
+++ b/frontend/src/components/Users/UsersModal/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import Modal from '@src/components/common/Modal';
+import { leaveTeam } from '@apis/team';
+
+interface Props {
+	handleModalClose: () => void;
+	teamId: number;
+}
+
+const UserModal: React.FC<Props> = ({ handleModalClose, teamId }) => {
+	const history = useHistory();
+	const handleSubmit = async () => {
+		const result = await leaveTeam(teamId);
+		history.push('/');
+	};
+	return (
+		<Modal handleModalClose={handleModalClose} handleSubmit={handleSubmit} removeSubmitButton={false}>
+			<div>정말 탈퇴하시겠습니까?</div>
+		</Modal>
+	);
+};
+
+export default UserModal;

--- a/frontend/src/components/Users/UsersModal/index.tsx
+++ b/frontend/src/components/Users/UsersModal/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import Modal from '@src/components/common/Modal';
 import { leaveTeam } from '@apis/team';
+import { Content } from './style';
 
 interface Props {
 	handleModalClose: () => void;
@@ -16,7 +17,7 @@ const UserModal: React.FC<Props> = ({ handleModalClose, teamId }) => {
 	};
 	return (
 		<Modal handleModalClose={handleModalClose} handleSubmit={handleSubmit} removeSubmitButton={false}>
-			<div>정말 탈퇴하시겠습니까?</div>
+			<Content>정말 탈퇴하시겠습니까?</Content>
 		</Modal>
 	);
 };

--- a/frontend/src/components/Users/UsersModal/style.ts
+++ b/frontend/src/components/Users/UsersModal/style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Content = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-family: inherit;
+	padding: 0 0 10% 0;
+`;

--- a/frontend/src/pages/UsersPage/index.tsx
+++ b/frontend/src/pages/UsersPage/index.tsx
@@ -16,18 +16,18 @@ const UsersPage: React.FC<Props> = ({ match }) => {
 
 	const socketRef = useContext(SocketContext);
 
-	// useEffect(() => {
-	// 	if (socketRef.current) {
-	// 		socketRef.current.on('online users', (data: any) => {
-	// 			console.log(data);
-	// 		});
-	// 		socketRef.current.emit('enter users room');
-	// 	}
-	// 	return () => {
-	// 		socketRef.current.emit('leave users room');
-	// 		socketRef.current.off('online users');
-	// 	};
-	// }, [socketRef.current]);
+	useEffect(() => {
+		if (socketRef.current) {
+			socketRef.current.on('online users', (data: any) => {
+				console.log(data);
+			});
+			socketRef.current.emit('enter users room');
+		}
+		return () => {
+			socketRef.current.emit('leave users room');
+			socketRef.current.off('online users');
+		};
+	}, [socketRef.current]);
 
 	return (
 		<UsersTemplate

--- a/frontend/src/pages/UsersPage/index.tsx
+++ b/frontend/src/pages/UsersPage/index.tsx
@@ -1,24 +1,42 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useState } from 'react';
 import UsersTemplate from '@templates/UsersTemplate';
 import { SocketContext } from '@utils/socketContext';
+import { RouteComponentProps } from 'react-router';
 
-const UsersPage: React.FC = () => {
+interface MatchParams {
+	teamId: string;
+}
+
+type Props = RouteComponentProps<MatchParams>;
+
+const UsersPage: React.FC<Props> = ({ match }) => {
+	const [isModalVisible, setIsModalVisible] = useState(false);
+	const handleModalClose = () => setIsModalVisible(false);
+	const handleModalOpen = () => setIsModalVisible(true);
+
 	const socketRef = useContext(SocketContext);
 
-	useEffect(() => {
-		if (socketRef.current) {
-			socketRef.current.on('online users', (data: any) => {
-				console.log(data);
-			});
-			socketRef.current.emit('enter users room');
-		}
-		return () => {
-			socketRef.current.emit('leave users room');
-			socketRef.current.off('online users');
-		};
-	}, [socketRef.current]);
+	// useEffect(() => {
+	// 	if (socketRef.current) {
+	// 		socketRef.current.on('online users', (data: any) => {
+	// 			console.log(data);
+	// 		});
+	// 		socketRef.current.emit('enter users room');
+	// 	}
+	// 	return () => {
+	// 		socketRef.current.emit('leave users room');
+	// 		socketRef.current.off('online users');
+	// 	};
+	// }, [socketRef.current]);
 
-	return <UsersTemplate />;
+	return (
+		<UsersTemplate
+			teamId={Number(match.params.teamId)}
+			handleModalOpen={handleModalOpen}
+			handleModalClose={handleModalClose}
+			isModalVisible={isModalVisible}
+		/>
+	);
 };
 
 export default UsersPage;

--- a/frontend/src/routes/TeamRoute.tsx
+++ b/frontend/src/routes/TeamRoute.tsx
@@ -28,7 +28,7 @@ const TeamRoute = ({ computedMatch }: any) => {
 		<SocketContext.Provider value={socketRef}>
 			<PrivateRoute exact path='/team/:teamId/chat' component={ChatPage} />
 			<PrivateRoute exact path='/team/:teamId/calendar' component={CalendarPage} />
-			<PrivateRoute exact path='/team/:teamId/users' component={UsersPage} />
+			<PrivateRoute exact path='/team/:teamId/users' component={UsersPage} teamId={teamId} />
 		</SocketContext.Provider>
 	);
 };

--- a/frontend/src/templates/UsersTemplate/index.tsx
+++ b/frontend/src/templates/UsersTemplate/index.tsx
@@ -1,15 +1,29 @@
-import React from 'react';
-import { Header, Navbar, Sidebar } from '@components/common';
+import React, { useEffect, useState } from 'react';
+import { Header, Navbar } from '@components/common';
 import UsersHeader from '@components/Users/UsersHeader';
 import Users from '@src/components/Users/UserList';
+import { readTeamInfo } from '@src/apis/users';
+import UserModal from '@src/components/Users/UsersModal';
 import { MainContainer, ContentContainer } from './style';
 
-const UsersTemplate: React.FC = () => {
-	const teamInfo = {
-		teamId: 1,
-		teamName: 'boostcamp web-29',
-		teamDesc: '팀 성명 정보입니다.',
+interface Props {
+	teamId: number;
+	isModalVisible: boolean;
+	handleModalClose: () => void;
+	handleModalOpen: () => void;
+}
+
+const UsersTemplate: React.FC<Props> = ({ teamId, handleModalOpen, handleModalClose, isModalVisible }) => {
+	const [teamInfo, setTeamInfo] = useState({});
+	const getTeam = async () => {
+		const result = await readTeamInfo(teamId);
+		setTeamInfo(result);
 	};
+
+	useEffect(() => {
+		getTeam();
+	}, []);
+
 	return (
 		<>
 			<Header />
@@ -17,9 +31,10 @@ const UsersTemplate: React.FC = () => {
 				<Navbar />
 				<ContentContainer>
 					<UsersHeader teamInfo={teamInfo} />
-					<Users />
+					<Users teamId={teamId} handleModalOpen={handleModalOpen} />
 				</ContentContainer>
 			</MainContainer>
+			{isModalVisible && <UserModal handleModalClose={handleModalClose} teamId={teamId} />}
 		</>
 	);
 };


### PR DESCRIPTION
## 작업 내용
- [x] 팀, 유저 정보 가져오기 (기존 하드코딩)
- [x] 팀 탈퇴

## 주요 변경 사항

## 구현 스크린샷 (선택)
![Animation](https://user-images.githubusercontent.com/70019911/141978222-4488f274-f959-42ea-b904-e7f85abdc4d3.gif)

## 궁금한점
1. 팀을 탈퇴하고 history api로 홈으로 redirect하게 했는데, 홈으로 잘 가긴 가는데 rerendering이 안돼서 탈퇴한 팀이 계속 보이네요. 새로고침 하면 사라지는데 어떻게 해결하면 좋을까요??
2. 모달이 있는걸 그대로 쓰다보니까 이렇게 됐는데 새로 만드는게 좋겠죠....?ㅎㅎ
