### PR TITLE
[Feat/chat#91#99] 채팅 페이지 모드 설정, 유저 초대 검색 필터링,

### DIFF
--- a/backend/src/controllers/chat-controller.ts
+++ b/backend/src/controllers/chat-controller.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import ChatRoomService from '@src/services/chat-room-service';
+
+const ChatController = {
+	async createChatRoom(req: Request, res: Response) {
+		try {
+			const chatRoomInfo = req.body;
+			const newChatRoomInfo = await ChatRoomService.getInstance().createChatRoom(chatRoomInfo);
+			res.json(newChatRoomInfo);
+		} catch (err) {
+			res.sendStatus(409);
+		}
+	}
+};
+
+export default ChatController;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import userRouter from '@routes/user-router';
 import authRouter from '@routes/auth-router';
 import scheduleRouter from '@routes/schedule-router';
 import teamRouter from '@routes/team-router';
+import chatRouter from '@routes/chat-router';
 
 class App {
 	app: express.Application;
@@ -55,6 +56,7 @@ class App {
 		this.app.use('/api/auth', authRouter);
 		this.app.use('/api/schedule', scheduleRouter);
 		this.app.use('/api/team', teamRouter);
+		this.app.use('/api/chat', chatRouter);
 	}
 
 	listen() {

--- a/backend/src/routes/chat-router.ts
+++ b/backend/src/routes/chat-router.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import ChatController from '@controllers/chat-controller';
+
+const router = express.Router();
+
+router.post('/room', ChatController.createChatRoom);
+
+export default router;

--- a/backend/src/services/chat-room-service.ts
+++ b/backend/src/services/chat-room-service.ts
@@ -1,0 +1,37 @@
+import { getCustomRepository } from 'typeorm';
+import ChatRoomRepository from '@repositories/chat_room-repository';
+import ChatRoomUserRepository from '@repositories/chat_room-user-repository';
+
+class ChatRoomService {
+	static instance: ChatRoomService;
+	chatRoomRepository: ChatRoomRepository;
+	chatRoomUserRepository: ChatRoomUserRepository;
+
+	constructor() {
+		this.chatRoomRepository = getCustomRepository(ChatRoomRepository);
+		this.chatRoomUserRepository = getCustomRepository(ChatRoomUserRepository);
+	}
+
+	static getInstance(): ChatRoomService {
+		if (!ChatRoomService.instance) {
+			ChatRoomService.instance = new ChatRoomService();
+		}
+		return ChatRoomService.instance;
+	}
+
+	async createChatRoom(chatRoomInfo: ChatRoomInfoType) {
+		const { team_id, chat_room_name, user_email_list } = chatRoomInfo;
+		const newChatRoom = await this.chatRoomRepository.save({ team_id, chat_room_name });
+		if (!newChatRoom) throw new Error('채팅방 만들기 실패');
+		// await this.chatRoomUserRepository.save({ user_id, chat_room_id: newChatRoom.chat_room_id});
+		return newChatRoom;
+	}
+}
+
+interface ChatRoomInfoType {
+	team_id: number;
+	chat_room_name: string;
+	user_email_list: string[];
+}
+
+export default ChatRoomService;

--- a/frontend/src/components/Chat/ChatContent/index.tsx
+++ b/frontend/src/components/Chat/ChatContent/index.tsx
@@ -1,36 +1,16 @@
 import React from 'react';
 import { FaTelegramPlane } from 'react-icons/fa';
 import Message from './Message';
+import { messages } from '../dataStructure';
 import { Container, MessagesContainer, InputContainer } from './style';
-
-const messages = [
-	{ message_id: 1, user_id: 1, user_name: 'user1', content: 'hi', created_at: new Date() },
-	{ message_id: 2, user_id: 2, user_name: 'user2', content: 'hi2', created_at: new Date() },
-	{ message_id: 3, user_id: 3, user_name: 'user3', content: 'hi3', created_at: new Date() },
-	{
-		message_id: 4,
-		user_id: 4,
-		user_name: 'user4',
-		content: 'hiㅁㅎㅇㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㅁㅇㅎㄴㅇㅎㄴㅇㅎㄴㅁㅎㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㄴㅇㄴㅇㅎㄴㅎㅇ4',
-		created_at: new Date(),
-	},
-	{ message_id: 5, user_id: 5, user_name: 'user5', content: 'hi3', created_at: new Date() },
-	{ message_id: 6, user_id: 6, user_name: 'user6', content: 'hi4', created_at: new Date() },
-	{ message_id: 7, user_id: 7, user_name: 'user7', content: 'hi3', created_at: new Date() },
-	{ message_id: 8, user_id: 3, user_name: 'user8', content: 'hi4', created_at: new Date() },
-	{ message_id: 9, user_id: 3, user_name: 'user9', content: 'hi3', created_at: new Date() },
-	{ message_id: 10, user_id: 10, user_name: 'user10', content: 'hi4', created_at: new Date() },
-	{ message_id: 11, user_id: 11, user_name: 'user11', content: 'hi3', created_at: new Date() },
-	{ message_id: 12, user_id: 12, user_name: 'user12', content: 'hi4', created_at: new Date() },
-];
 
 const ChatContent: React.FC = () => {
 	return (
 		<Container>
 			<MessagesContainer>
-				{messages.map((message) => (
+				{/* {messages.map((message) => (
 					<Message key={message.message_id} message={message} />
-				))}
+				))} */}
 			</MessagesContainer>
 			<InputContainer>
 				<input type='text' placeholder='새 메시지 입력' />

--- a/frontend/src/components/Chat/ChatContent/index.tsx
+++ b/frontend/src/components/Chat/ChatContent/index.tsx
@@ -1,17 +1,28 @@
 import React from 'react';
 import { FaTelegramPlane } from 'react-icons/fa';
 import Message from './Message';
-import { messages } from '../dataStructure';
-import { Container, MessagesContainer, InputContainer } from './style';
+import { messages, ChatModeType } from '../dataStructure';
+import { Container, MessagesContainer, NoticeContainer, InputContainer } from './style';
 
-const ChatContent: React.FC = () => {
+interface Props {
+	chatMode: ChatModeType;
+}
+
+const ChatContent: React.FC<Props> = ({ chatMode }) => {
 	return (
 		<Container>
-			<MessagesContainer>
-				{/* {messages.map((message) => (
-					<Message key={message.message_id} message={message} />
-				))} */}
-			</MessagesContainer>
+			{chatMode === 'chat' ? (
+				<MessagesContainer>
+					{messages.map((message) => (
+						<Message key={message.message_id} message={message} />
+					))}
+				</MessagesContainer>
+			) : (
+				<NoticeContainer>
+					<span>새 대화를 시작하고 있습니다.</span>
+					<span>아래에 첫 번째 메시지를 입력하세요.</span>
+				</NoticeContainer>
+			)}
 			<InputContainer>
 				<input type='text' placeholder='새 메시지 입력' />
 				<FaTelegramPlane />

--- a/frontend/src/components/Chat/ChatContent/style.ts
+++ b/frontend/src/components/Chat/ChatContent/style.ts
@@ -21,6 +21,24 @@ export const MessagesContainer = styled.div`
 	}
 `;
 
+export const NoticeContainer = styled.div`
+	position: absolute;
+	top: 0;
+	bottom: 4.6rem;
+	left: 0;
+	right: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	span {
+		color: ${ColorCode.FONT1};
+		font-weight: bold;
+		display: block;
+		margin-bottom: 1rem;
+	}
+`;
+
 export const InputContainer = styled.div`
 	position: absolute;
 	bottom: 0;

--- a/frontend/src/components/Chat/ChatHeader/index.tsx
+++ b/frontend/src/components/Chat/ChatHeader/index.tsx
@@ -1,10 +1,25 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { ProfileIcon } from '@components/common';
-import { FaUserPlus, FaPen } from 'react-icons/fa';
-import { Container, HeaderContainer, InputHeaderContainer, ChatRoomInfoContainer, InvitationBtn } from './style';
+import { FaUserPlus, FaPen, FaTimes } from 'react-icons/fa';
+import { UserType, userEx } from '../dataStructure';
+
+import {
+	Container,
+	HeaderContainer,
+	InputHeaderContainer,
+	UserListContainer,
+	InputWrapper,
+	SearchContainer,
+	UserContainer,
+	ChatRoomInfoContainer,
+	InvitationBtn,
+} from './style';
 
 interface Props {
 	newChatMode: boolean;
+	inviteUsers: UserType[];
+	addInviteUser: (newUser: UserType) => void;
+	deleteInviteUser: (email: string) => void;
 }
 
 const chatRoomInfo = {
@@ -13,12 +28,73 @@ const chatRoomInfo = {
 	userList: ['user1', 'user2', 'user3'],
 };
 
-const ChatHeader: React.FC<Props> = ({ newChatMode }) => {
+const ChatHeader: React.FC<Props> = ({ newChatMode, inviteUsers, addInviteUser, deleteInviteUser }) => {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [userSearchResult, setUserSearchResult] = useState<UserType[]>([]);
+
+	const searchByKey = (searchKey: string, userList: UserType[]): UserType[] => {
+		return userList.filter((user) => {
+			const regex = new RegExp(searchKey, 'gi');
+			return user.user_email.match(regex) || user.user_name.match(regex);
+		});
+	};
+
+	const handleSearchByKey = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const searchKey = e.currentTarget.value;
+		const matches = !searchKey ? [] : searchByKey(searchKey, userEx);
+		setUserSearchResult(matches);
+	};
+
+	const handleUserClick = (userEmail: string) => {
+		const user = userEx.find((user) => user.user_email === userEmail);
+		if (user) addToInvitationList(user);
+	};
+
+	const handleKeyPress = (e: React.KeyboardEvent) => {
+		if (e.key !== 'Enter') return;
+		e.preventDefault();
+		addToInvitationList(userSearchResult[0]); // enter 눌렀을 때 첫번째 결과로 입력
+	};
+
+	const addToInvitationList = (user: UserType) => {
+		if (!inputRef.current) return;
+		if (inviteUsers.find((invitedUser) => invitedUser.user_email === user.user_email)) return;
+		addInviteUser(user);
+		setUserSearchResult([]);
+		inputRef.current.value = '';
+	};
+
 	return (
 		<Container>
 			{newChatMode ? (
 				<InputHeaderContainer>
-					<input type='text' placeholder='대상: 이름 입력' />
+					<UserListContainer>
+						{inviteUsers.map((user) => (
+							<div key={user.user_email}>
+								<span>{user.user_name}</span>
+								<FaTimes onClick={() => deleteInviteUser(user.user_email)} />
+							</div>
+						))}
+					</UserListContainer>
+					<InputWrapper>
+						<input
+							type='text'
+							placeholder='초대할 유저 이름 입력'
+							ref={inputRef}
+							onChange={handleSearchByKey}
+							onKeyDown={handleKeyPress}
+						/>
+					</InputWrapper>
+					<SearchContainer>
+						{userSearchResult.map((user) => (
+							<UserContainer key={user.user_email} onClick={() => handleUserClick(user.user_email)}>
+								<ProfileIcon name={user.user_name} color={0} status='none' width={2.4} isHover={false} />
+								<span>
+									{user.user_name} ({user.user_email})
+								</span>
+							</UserContainer>
+						))}
+					</SearchContainer>
 				</InputHeaderContainer>
 			) : (
 				<HeaderContainer>

--- a/frontend/src/components/Chat/ChatHeader/index.tsx
+++ b/frontend/src/components/Chat/ChatHeader/index.tsx
@@ -16,7 +16,7 @@ import {
 } from './style';
 
 interface Props {
-	newChatMode: boolean;
+	chatMode: string;
 	inviteUsers: UserType[];
 	addInviteUser: (newUser: UserType) => void;
 	deleteInviteUser: (email: string) => void;
@@ -28,7 +28,7 @@ const chatRoomInfo = {
 	userList: ['user1', 'user2', 'user3'],
 };
 
-const ChatHeader: React.FC<Props> = ({ newChatMode, inviteUsers, addInviteUser, deleteInviteUser }) => {
+const ChatHeader: React.FC<Props> = ({ chatMode, inviteUsers, addInviteUser, deleteInviteUser }) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [userSearchResult, setUserSearchResult] = useState<UserType[]>([]);
 
@@ -66,7 +66,7 @@ const ChatHeader: React.FC<Props> = ({ newChatMode, inviteUsers, addInviteUser, 
 
 	return (
 		<Container>
-			{newChatMode ? (
+			{chatMode === 'create' ? (
 				<InputHeaderContainer>
 					<UserListContainer>
 						{inviteUsers.map((user) => (

--- a/frontend/src/components/Chat/ChatHeader/style.ts
+++ b/frontend/src/components/Chat/ChatHeader/style.ts
@@ -1,9 +1,16 @@
-import { ColorCode } from '@src/utils/constants';
+import { ColorCode, Font } from '@src/utils/constants';
 import styled from 'styled-components';
 
+interface UserContainerProps {
+	select: boolean;
+}
+
 export const Container = styled.div`
+	position: absolute;
+	width: 100%;
 	height: 3.5rem;
 	border-bottom: solid 1px ${ColorCode.LINE2};
+	z-index: 15;
 `;
 
 export const HeaderContainer = styled.div`
@@ -49,4 +56,74 @@ export const ChatRoomInfoContainer = styled.div`
 	}
 `;
 
-export const InputHeaderContainer = styled.div``;
+export const InputHeaderContainer = styled.div`
+	min-height: 100%;
+	background-color: ${ColorCode.WHITE};
+	padding: 0 0.6rem;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	border-bottom: solid 2px transparent;
+	:focus-within {
+		border-style: outset;
+		border-bottom: solid 2px ${ColorCode.PRIMARY1};
+	}
+`;
+
+export const UserListContainer = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	div {
+		display: flex;
+		padding: 0.5rem;
+		margin: 0.5rem 0.3rem;
+		background-color: ${ColorCode.BACKGROUND1};
+		border-radius: 10px;
+		span {
+			font-size: ${Font.SMALL};
+		}
+		svg {
+			width: 0.6rem;
+			margin-left: 0.4rem;
+			color: ${ColorCode.LINE3};
+			cursor: pointer;
+		}
+	}
+`;
+
+export const InputWrapper = styled.div`
+	flex-grow: 1;
+	input {
+		width: 100%;
+		height: 3rem;
+		padding-left: 0.5rem;
+		border: none;
+		outline: none;
+	}
+`;
+
+export const SearchContainer = styled.div`
+	position: absolute;
+	top: 3.5rem;
+	left: 3rem;
+	right: 3rem;
+	background-color: ${ColorCode.WHITE};
+	border-radius: 0 0 8px 8px;
+`;
+
+export const UserContainer = styled.div`
+	display: flex;
+	align-items: center;
+	padding-left: 0.8rem;
+	height: 3rem;
+	cursor: pointer;
+	border-radius: 8px;
+	span {
+		color: ${ColorCode.FONT1};
+		font-size: ${Font.SMALL};
+	}
+	:hover {
+		background-color: ${ColorCode.LINE1};
+	}
+`;

--- a/frontend/src/components/Chat/ChatSidebar/index.tsx
+++ b/frontend/src/components/Chat/ChatSidebar/index.tsx
@@ -2,35 +2,36 @@ import React from 'react';
 import { Sidebar, ProfileIcon } from '@components/common';
 import { BiListPlus } from 'react-icons/bi';
 import { timeSince } from '@utils/time';
+import { chatRooms } from '../dataStructure';
 import { SidebarHeader, ChatRoomsContainer, ChatRoom, ChatRoomInfoContainer, ChatRoomInfo, NewChatBtn } from './style';
 
-const chatRooms = [
-	{
-		title: '채팅방1',
-		id: 1,
-		previewChat: { message: '안녕아아아아아아아아아아아아아아아아아아아아아아아아', name: '나', date: new Date() },
-	},
-	{ title: '채팅방2', id: 2, previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 15, 12, 0) } },
-	{ title: '채팅방3', id: 3, previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 14, 12, 0) } },
-	{ title: '채팅방4', id: 4, previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 7, 12, 0) } },
-	{ title: '채팅방5', id: 5, previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 5, 12, 0) } },
-	{ title: '채팅방6', id: 6, previewChat: { message: '안녕', name: '나', date: new Date(2021, 9, 17, 12, 0) } },
-	{ title: '채팅방7', id: 7, previewChat: { message: '안녕', name: '나', date: new Date(2021, 9, 1, 12, 0) } },
-];
+interface Props {
+	setChatModeToNone: () => void;
+	setChatModeToCreate: () => void;
+	setChatModeToChat: () => void;
+}
 
-const ChatSidebar: React.FC = () => {
+const ChatSidebar: React.FC<Props> = ({ setChatModeToNone, setChatModeToCreate, setChatModeToChat }) => {
 	return (
 		<Sidebar>
 			<SidebarHeader>
-				<h2>채팅</h2>
-				<NewChatBtn>
+				<button type='button' onClick={setChatModeToNone}>
+					채팅
+				</button>
+				<NewChatBtn onClick={setChatModeToCreate}>
 					<BiListPlus />
 				</NewChatBtn>
 			</SidebarHeader>
 			<ChatRoomsContainer>
 				{chatRooms.map((chatRoom) => (
-					<ChatRoom key={chatRoom.id} focus={false}>
-						<ProfileIcon name={chatRoom.title} color={chatRoom.id % 6} status='none' width={3.2} isHover={false} />
+					<ChatRoom key={chatRoom.chat_room_id} focus={false} onClick={setChatModeToChat}>
+						<ProfileIcon
+							name={chatRoom.title}
+							color={chatRoom.chat_room_id % 6}
+							status='none'
+							width={3.2}
+							isHover={false}
+						/>
 						<ChatRoomInfoContainer>
 							<ChatRoomInfo>
 								<h3>{chatRoom.title}</h3>

--- a/frontend/src/components/Chat/ChatSidebar/style.ts
+++ b/frontend/src/components/Chat/ChatSidebar/style.ts
@@ -12,8 +12,11 @@ export const SidebarHeader = styled.div`
 	justify-content: space-between;
 	padding-left: 1rem;
 	border-bottom: solid 1px ${ColorCode.LINE2};
-	h2 {
+	button {
+		font-size: ${Font.MEDIUM};
 		font-weight: bold;
+		border: none;
+		cursor: pointer;
 	}
 `;
 
@@ -25,6 +28,8 @@ export const NewChatBtn = styled.button`
 	border: none;
 	background-color: transparent;
 	margin-right: 0.4rem;
+	display: flex;
+	align-items: center;
 	svg {
 		width: 1.5rem;
 		height: 1.5rem;

--- a/frontend/src/components/Chat/dataStructure.ts
+++ b/frontend/src/components/Chat/dataStructure.ts
@@ -1,0 +1,11 @@
+export interface UserType {
+	user_name: string;
+	user_email: string;
+}
+
+export const userEx: UserType[] = [
+	{ user_name: '강민지', user_email: 'test1@test.com' },
+	{ user_name: '이명재', user_email: 'test2@test.com' },
+	{ user_name: '이원주', user_email: 'test3@test.com' },
+	{ user_name: '장수용', user_email: 'test4@test.com' },
+];

--- a/frontend/src/components/Chat/dataStructure.ts
+++ b/frontend/src/components/Chat/dataStructure.ts
@@ -9,3 +9,62 @@ export const userEx: UserType[] = [
 	{ user_name: '이원주', user_email: 'test3@test.com' },
 	{ user_name: '장수용', user_email: 'test4@test.com' },
 ];
+
+export const chatRooms = [
+	{
+		title: '채팅방1',
+		chat_room_id: 1,
+		previewChat: { message: '안녕아아아아아아아아아아아아아아아아아아아아아아아아', name: '나', date: new Date() },
+	},
+	{
+		title: '채팅방2',
+		chat_room_id: 2,
+		previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 15, 12, 0) },
+	},
+	{
+		title: '채팅방3',
+		chat_room_id: 3,
+		previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 14, 12, 0) },
+	},
+	{
+		title: '채팅방4',
+		chat_room_id: 4,
+		previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 7, 12, 0) },
+	},
+	{
+		title: '채팅방5',
+		chat_room_id: 5,
+		previewChat: { message: '안녕', name: '나', date: new Date(2021, 10, 5, 12, 0) },
+	},
+	{
+		title: '채팅방6',
+		chat_room_id: 6,
+		previewChat: { message: '안녕', name: '나', date: new Date(2021, 9, 17, 12, 0) },
+	},
+	{
+		title: '채팅방7',
+		chat_room_id: 7,
+		previewChat: { message: '안녕', name: '나', date: new Date(2021, 9, 1, 12, 0) },
+	},
+];
+
+export const messages = [
+	{ message_id: 1, user_id: 1, user_name: 'user1', content: 'hi', created_at: new Date() },
+	{ message_id: 2, user_id: 2, user_name: 'user2', content: 'hi2', created_at: new Date() },
+	{ message_id: 3, user_id: 3, user_name: 'user3', content: 'hi3', created_at: new Date() },
+	{
+		message_id: 4,
+		user_id: 4,
+		user_name: 'user4',
+		content: 'hiㅁㅎㅇㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㅁㅇㅎㄴㅇㅎㄴㅇㅎㄴㅁㅎㄴㅇㅎㄴㅇㅎㄴㅇㅎㄴㄴㅇㄴㅇㅎㄴㅎㅇ4',
+		created_at: new Date(),
+	},
+	{ message_id: 5, user_id: 5, user_name: 'user5', content: 'hi3', created_at: new Date() },
+	{ message_id: 6, user_id: 6, user_name: 'user6', content: 'hi4', created_at: new Date() },
+	{ message_id: 7, user_id: 7, user_name: 'user7', content: 'hi3', created_at: new Date() },
+	{ message_id: 8, user_id: 3, user_name: 'user8', content: 'hi4', created_at: new Date() },
+	{ message_id: 9, user_id: 3, user_name: 'user9', content: 'hi3', created_at: new Date() },
+	{ message_id: 10, user_id: 10, user_name: 'user10', content: 'hi4', created_at: new Date() },
+	{ message_id: 11, user_id: 11, user_name: 'user11', content: 'hi3', created_at: new Date() },
+	{ message_id: 12, user_id: 12, user_name: 'user12', content: 'hi4', created_at: new Date() },
+];

--- a/frontend/src/components/Chat/dataStructure.ts
+++ b/frontend/src/components/Chat/dataStructure.ts
@@ -3,6 +3,8 @@ export interface UserType {
 	user_email: string;
 }
 
+export type ChatModeType = 'none' | 'create' | 'chat';
+
 export const userEx: UserType[] = [
 	{ user_name: '강민지', user_email: 'test1@test.com' },
 	{ user_name: '이명재', user_email: 'test2@test.com' },

--- a/frontend/src/components/common/Navbar/style.ts
+++ b/frontend/src/components/common/Navbar/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { ColorCode } from '@utils/constants';
 
 export const Container = styled.nav`
+	flex-shrink: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/frontend/src/components/common/Sidebar/style.ts
+++ b/frontend/src/components/common/Sidebar/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { ColorCode } from '@utils/constants';
 
 export const Container = styled.div`
+	flex-shrink: 0;
 	position: relative;
 	background-color: ${ColorCode.BACKGROUND2};
 	width: 17rem;

--- a/frontend/src/pages/ChatPage/index.tsx
+++ b/frontend/src/pages/ChatPage/index.tsx
@@ -1,10 +1,35 @@
-import React, { useState } from 'react';
+import React, { useState, useReducer } from 'react';
 import ChatTemplate from '@templates/ChatTemplate';
+import { UserType } from '@components/Chat/dataStructure';
+
+type InviteUsersAction = { type: 'ADD'; newUser: UserType } | { type: 'DELETE'; email: string };
+
+const inviteUsersReducer = (inviteUsers: UserType[], action: InviteUsersAction): UserType[] => {
+	switch (action.type) {
+		case 'ADD':
+			return [...inviteUsers, action.newUser];
+		case 'DELETE':
+			return [...inviteUsers.filter((users) => users.user_email !== action.email)];
+		default:
+			throw new Error();
+	}
+};
 
 const ChatPage: React.FC = () => {
-	const [newChatMode, setNewChatMode] = useState(false);
+	const [newChatMode, setNewChatMode] = useState(true);
+	const [inviteUsers, dispatchInviteUsers] = useReducer(inviteUsersReducer, []);
 
-	return <ChatTemplate newChatMode={newChatMode} />;
+	const addInviteUser = (newUser: UserType) => dispatchInviteUsers({ type: 'ADD', newUser });
+	const deleteInviteUser = (email: string) => dispatchInviteUsers({ type: 'DELETE', email });
+
+	return (
+		<ChatTemplate
+			newChatMode={newChatMode}
+			inviteUsers={inviteUsers}
+			addInviteUser={addInviteUser}
+			deleteInviteUser={deleteInviteUser}
+		/>
+	);
 };
 
 export default ChatPage;

--- a/frontend/src/pages/ChatPage/index.tsx
+++ b/frontend/src/pages/ChatPage/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useReducer } from 'react';
 import ChatTemplate from '@templates/ChatTemplate';
-import { UserType } from '@components/Chat/dataStructure';
+import { UserType, ChatModeType } from '@components/Chat/dataStructure';
 
 type InviteUsersAction = { type: 'ADD'; newUser: UserType } | { type: 'DELETE'; email: string };
 
@@ -14,8 +14,6 @@ const inviteUsersReducer = (inviteUsers: UserType[], action: InviteUsersAction):
 			throw new Error();
 	}
 };
-
-type ChatModeType = 'none' | 'create' | 'chat';
 
 const ChatPage: React.FC = () => {
 	const [chatMode, setChatMode] = useState<ChatModeType>('none');

--- a/frontend/src/pages/ChatPage/index.tsx
+++ b/frontend/src/pages/ChatPage/index.tsx
@@ -15,17 +15,26 @@ const inviteUsersReducer = (inviteUsers: UserType[], action: InviteUsersAction):
 	}
 };
 
+type ChatModeType = 'none' | 'create' | 'chat';
+
 const ChatPage: React.FC = () => {
-	const [newChatMode, setNewChatMode] = useState(true);
+	const [chatMode, setChatMode] = useState<ChatModeType>('none');
 	const [inviteUsers, dispatchInviteUsers] = useReducer(inviteUsersReducer, []);
 
 	const addInviteUser = (newUser: UserType) => dispatchInviteUsers({ type: 'ADD', newUser });
 	const deleteInviteUser = (email: string) => dispatchInviteUsers({ type: 'DELETE', email });
 
+	const setChatModeToNone = () => setChatMode('none');
+	const setChatModeToCreate = () => setChatMode('create');
+	const setChatModeToChat = () => setChatMode('chat');
+
 	return (
 		<ChatTemplate
-			newChatMode={newChatMode}
+			chatMode={chatMode}
 			inviteUsers={inviteUsers}
+			setChatModeToNone={setChatModeToNone}
+			setChatModeToCreate={setChatModeToCreate}
+			setChatModeToChat={setChatModeToChat}
 			addInviteUser={addInviteUser}
 			deleteInviteUser={deleteInviteUser}
 		/>

--- a/frontend/src/templates/ChatTemplate/index.tsx
+++ b/frontend/src/templates/ChatTemplate/index.tsx
@@ -3,13 +3,17 @@ import { Header, Navbar } from '@components/common';
 import ChatSidebar from '@components/Chat/ChatSidebar';
 import ChatHeader from '@components/Chat/ChatHeader';
 import ChatContent from '@components/Chat/ChatContent';
+import { UserType } from '@components/Chat/dataStructure';
 import { Layout, MainContainer, ChatContainer } from './style';
 
 interface Props {
 	newChatMode: boolean;
+	inviteUsers: UserType[];
+	addInviteUser: (newUser: UserType) => void;
+	deleteInviteUser: (email: string) => void;
 }
 
-const ChatTemplate: React.FC<Props> = ({ newChatMode }) => {
+const ChatTemplate: React.FC<Props> = ({ newChatMode, inviteUsers, addInviteUser, deleteInviteUser }) => {
 	return (
 		<Layout>
 			<Header />
@@ -17,7 +21,12 @@ const ChatTemplate: React.FC<Props> = ({ newChatMode }) => {
 				<Navbar />
 				<ChatSidebar />
 				<ChatContainer>
-					<ChatHeader newChatMode={newChatMode} />
+					<ChatHeader
+						newChatMode={newChatMode}
+						inviteUsers={inviteUsers}
+						addInviteUser={addInviteUser}
+						deleteInviteUser={deleteInviteUser}
+					/>
 					<ChatContent />
 				</ChatContainer>
 			</MainContainer>

--- a/frontend/src/templates/ChatTemplate/index.tsx
+++ b/frontend/src/templates/ChatTemplate/index.tsx
@@ -7,28 +7,45 @@ import { UserType } from '@components/Chat/dataStructure';
 import { Layout, MainContainer, ChatContainer } from './style';
 
 interface Props {
-	newChatMode: boolean;
+	chatMode: string;
 	inviteUsers: UserType[];
+	setChatModeToNone: () => void;
+	setChatModeToCreate: () => void;
+	setChatModeToChat: () => void;
 	addInviteUser: (newUser: UserType) => void;
 	deleteInviteUser: (email: string) => void;
 }
 
-const ChatTemplate: React.FC<Props> = ({ newChatMode, inviteUsers, addInviteUser, deleteInviteUser }) => {
+const ChatTemplate: React.FC<Props> = ({
+	chatMode,
+	inviteUsers,
+	setChatModeToNone,
+	setChatModeToCreate,
+	setChatModeToChat,
+	addInviteUser,
+	deleteInviteUser,
+}) => {
 	return (
 		<Layout>
 			<Header />
 			<MainContainer>
 				<Navbar />
-				<ChatSidebar />
-				<ChatContainer>
-					<ChatHeader
-						newChatMode={newChatMode}
-						inviteUsers={inviteUsers}
-						addInviteUser={addInviteUser}
-						deleteInviteUser={deleteInviteUser}
-					/>
-					<ChatContent />
-				</ChatContainer>
+				<ChatSidebar
+					setChatModeToNone={setChatModeToNone}
+					setChatModeToCreate={setChatModeToCreate}
+					setChatModeToChat={setChatModeToChat}
+				/>
+				{chatMode !== 'none' && (
+					<ChatContainer>
+						<ChatHeader
+							chatMode={chatMode}
+							inviteUsers={inviteUsers}
+							addInviteUser={addInviteUser}
+							deleteInviteUser={deleteInviteUser}
+						/>
+						<ChatContent />
+					</ChatContainer>
+				)}
 			</MainContainer>
 		</Layout>
 	);

--- a/frontend/src/templates/ChatTemplate/index.tsx
+++ b/frontend/src/templates/ChatTemplate/index.tsx
@@ -3,11 +3,11 @@ import { Header, Navbar } from '@components/common';
 import ChatSidebar from '@components/Chat/ChatSidebar';
 import ChatHeader from '@components/Chat/ChatHeader';
 import ChatContent from '@components/Chat/ChatContent';
-import { UserType } from '@components/Chat/dataStructure';
+import { UserType, ChatModeType } from '@components/Chat/dataStructure';
 import { Layout, MainContainer, ChatContainer } from './style';
 
 interface Props {
-	chatMode: string;
+	chatMode: ChatModeType;
 	inviteUsers: UserType[];
 	setChatModeToNone: () => void;
 	setChatModeToCreate: () => void;
@@ -43,7 +43,7 @@ const ChatTemplate: React.FC<Props> = ({
 							addInviteUser={addInviteUser}
 							deleteInviteUser={deleteInviteUser}
 						/>
-						<ChatContent />
+						<ChatContent chatMode={chatMode} />
 					</ChatContainer>
 				)}
 			</MainContainer>

--- a/frontend/src/templates/ChatTemplate/style.ts
+++ b/frontend/src/templates/ChatTemplate/style.ts
@@ -13,7 +13,6 @@ export const MainContainer = styled.div`
 	right: 0;
 	bottom: 0;
 	display: flex;
-	min-width: max-content;
 `;
 
 export const ChatContainer = styled.div`

--- a/frontend/src/templates/ChatTemplate/style.ts
+++ b/frontend/src/templates/ChatTemplate/style.ts
@@ -13,6 +13,7 @@ export const MainContainer = styled.div`
 	right: 0;
 	bottom: 0;
 	display: flex;
+	background-color: ${ColorCode.BACKGROUND1};
 `;
 
 export const ChatContainer = styled.div`


### PR DESCRIPTION
## 작업 내용
- [x] 채팅 모드에 따른 UI
- [x] 초대 input 검색 필터링
- [ ] 채팅방 생성 api 구현 (보류) 

## 주요 변경 사항
- 채팅 모드에 따른 UI
  - ` type ChatModeType = "none" | "create" | "chat"`
  -  3가지 타입으로 화면이 보여집니다.
  - none: '/team/teamId/chat`로 입장하였을 때, 사이드바에서 채팅 글자를 눌렀을 때, 채팅 목록만 보여지는 모드입니다.
  - create: 사이드바에서 채팅방 생성 버튼을 눌렀을 때, 채팅방 생성을 위한 화면이 보여지는 모드입니다.
  - chat: 채팅 목록에서 방을 눌렀을 때 채팅이 보여지는 모드입니다.

- 유저 초대 검색
  - 일단 더미 데이터로 정규식을 이용하여 필터링하였습니다.
  - 사용자 목록 가져오는 api는 수용님이 하신 것 같아서 내일 합쳐보는 걸로..
  - 키보드 enter 누르면 검색된 가장 위 유저로 추가됩니다.
  - 직접 클릭 하면 해당 유저로 추가됩니다.
  - 삭제 버튼을 누르면 삭제됩니다.
  - 이미 추가된 유저는 추가되지 않습니다.
  - 자신 추가 안되는 건 나중에 추가하려합니다..

## 구현 스크린샷 (선택)
- 채팅 모드에 따른 UI
![Animation1](https://user-images.githubusercontent.com/47925079/141990749-0111515d-e3ab-434d-8607-53cc03843fee.gif)
- 유저 초대 검색
![Animation2](https://user-images.githubusercontent.com/47925079/141991342-987df83c-45ce-46d0-a508-fa821bf23366.gif)

## 궁금한점
- 저희가 현재 user식별하는걸 다 userEmail로 하고 있는데 그럼 userId를 사용하기 위해서는 매번 userEmail 정보로 userId를 가져오거나 jwt로 가져와야 되는 건가요? 채팅 room 작업하려고 보니까 생각보다 일이 많아지네요.. 유저 정보를 가져올 때 처음부터 userId를 가져오지 않는 이유가 따로 있을까요?
- chatRoomId로 `/chat/chatRoomId`이런식으로 라우팅을 해야할까요? 제 생각은 라우팅 따로 안하고 방 정보를 상태로 관리하는게 새로고침할 때 소켓이나 여러 면에서 편리할 것 같은데 의견이 궁금합니다.