### PR TITLE
[Fix]Local Accout Signup오류 수정

### DIFF
--- a/backend/src/passport/github-strategy.ts
+++ b/backend/src/passport/github-strategy.ts
@@ -20,7 +20,8 @@ const getUserRawData = (userJson) => {
 const githubLoginCallback = async (accessToken, refreshToken, profile, callback) => {
 	const { user_email, user_password, github_name, github_id } = getUserRawData(profile._json);
 	let user = await UserService.getInstance().getUserByEmail(user_email);
-	if (!user) user = await UserService.getInstance().createUser(user_email, user_password, github_name, github_id);
+	if (!user)
+		user = await UserService.getInstance().createUser(user_email, user_password, github_name, github_id, github_name);
 	if (user && (github_id !== user.github_id || github_name !== user.github_name))
 		UserService.getInstance().updateUserToGithub(user.user_id, github_id, github_name);
 	return callback(null, user);

--- a/backend/src/services/user-service.ts
+++ b/backend/src/services/user-service.ts
@@ -34,21 +34,21 @@ class UserService {
 		user_email: string,
 		encryptedPassword: string,
 		user_name: string,
-		github_name?: string,
-		github_id?: string
+		github_id?: string,
+		github_name?: string
 	) {
 		const decryptedPassword = Crypto.AES.decrypt(encryptedPassword, process.env.AES_KEY).toString();
 		const user_password = bcrypt.hashSync(decryptedPassword, Number(process.env.SALT_OR_ROUNDS));
-		const user_color = Math.floor(Math.random() * 12); // TODO : user_color로 바꾸기
+		const user_color = Math.floor(Math.random() * 12);
+		const githubId = github_id ?? '';
 		const githubName = github_name ?? '';
-		const githubid = github_id ?? '';
 		const newUser = await this.userRepository.save({
 			user_email,
 			user_password,
 			user_name,
 			user_color,
-			github_name: githubName,
-			github_id: githubid
+			github_id: githubId,
+			github_name: githubName
 		});
 		return newUser;
 	}

--- a/backend/src/services/user-service.ts
+++ b/backend/src/services/user-service.ts
@@ -30,17 +30,25 @@ class UserService {
 		return { user_id, user_email, user_name, user_color, github_id, github_name };
 	}
 
-	async createUser(user_email: string, encryptedPassword: string, user_name: string, github_name?: string) {
+	async createUser(
+		user_email: string,
+		encryptedPassword: string,
+		user_name: string,
+		github_name?: string,
+		github_id?: string
+	) {
 		const decryptedPassword = Crypto.AES.decrypt(encryptedPassword, process.env.AES_KEY).toString();
 		const user_password = bcrypt.hashSync(decryptedPassword, Number(process.env.SALT_OR_ROUNDS));
 		const user_color = Math.floor(Math.random() * 12); // TODO : user_color로 바꾸기
-		const github = github_name ?? '';
+		const githubName = github_name ?? '';
+		const githubid = github_id ?? '';
 		const newUser = await this.userRepository.save({
 			user_email,
 			user_password,
 			user_name,
 			user_color,
-			github_name: github
+			github_name: githubName,
+			github_id: githubid
 		});
 		return newUser;
 	}


### PR DESCRIPTION
## 작업 내용
로컬 계정 생성관련 오류 수정

## 주요 변경 사항
- user entity에 `github_name`컬럼이 생김에 따라, local account signup이 정상적으로 진행되지 않음
- local account signup의 경우, `github_name`, `github_id` 컬럼의 값을 null이 아닌 ''(empty string)을 삽입 

## 추가 
- 데모 영상 촬영때 발생한 `팀 삭제가 안되는 버그`를 수정해 보려고 했습니다. 
- Foreign key constraint와 관련된 버그로 추정하고
1. team table ~ schedule table
2. team table ~ chat_room table
3. team table ~ team_user table
총 3개의 경우를 분석해 봤는데, 지금은 문제 없이 팀이 잘 삭제됩니다;; 그래서 따로 처리한 내용은 없습니다 하하; 나중에 문제 생기면 그때 고쳐보겠습니다