### PR TITLE
[팀 보드] 경쟁 상황 해결

### DIFF
--- a/backend/src/sockets/teamBoard.ts
+++ b/backend/src/sockets/teamBoard.ts
@@ -86,6 +86,7 @@ const makePostitObj = async (newData) => {
 		updatedAt: new Date(),
 		updatedBy: newData.updatedBy,
 		createdAt: new Date(),
-		createdBy: newData.createdBy
+		createdBy: newData.createdBy,
+		whoIsDragging: -1
 	};
 };

--- a/backend/src/sockets/teamBoard.ts
+++ b/backend/src/sockets/teamBoard.ts
@@ -30,11 +30,21 @@ const initTeamBoard = (socket: Socket) => {
 		}
 	});
 
-	socket.on('update postit', async (newPostit) => {
+	socket.on('update start postit', async (newPostit) => {
 		try {
 			const teamId = onlineUsersInfo[socket.id].teamId;
 			const updatedPostit = await redisClient.set('board', teamId, newPostit);
-			socket.broadcast.to('board').emit('drag postit', updatedPostit);
+			socket.broadcast.to('board').emit('update start postit', updatedPostit);
+		} catch (err) {
+			socket.emit('team board error', '포스트잇을 업데이트 할 수 없습니다!');
+		}
+	});
+
+	socket.on('update end postit', async (newPostit) => {
+		try {
+			const teamId = onlineUsersInfo[socket.id].teamId;
+			const updatedPostit = await redisClient.set('board', teamId, newPostit);
+			socket.broadcast.to('board').emit('update end postit', updatedPostit);
 		} catch (err) {
 			socket.emit('team board error', '포스트잇 업데이트 실패!');
 		}
@@ -87,6 +97,7 @@ const makePostitObj = async (newData) => {
 		updatedBy: newData.updatedBy,
 		createdAt: new Date(),
 		createdBy: newData.createdBy,
-		whoIsDragging: -1
+		whoIsDragging: -1,
+		whoIsUpdating: -1
 	};
 };

--- a/frontend/src/components/Board/Canvas/index.tsx
+++ b/frontend/src/components/Board/Canvas/index.tsx
@@ -4,12 +4,13 @@ import { KonvaEventObject } from 'konva/lib/Node';
 import { useRecoilValue } from 'recoil';
 import userState from '@src/stores/user';
 import { CANVAS } from '@utils/constants';
-import { IPostit } from '@src/types/board';
+import { IPostit, ISocketApi } from '@src/types/board';
 import { Dispatch, SetStateAction } from 'hoist-non-react-statics/node_modules/@types/react';
 import Postit from '../Postit';
 
 interface Props {
 	postits: IPostit[];
+	socketApi: ISocketApi;
 	getUserNameById: (userId: number) => string;
 	handleDrag: (e: KonvaEventObject<DragEvent>) => void;
 	handleDragStart: (e: KonvaEventObject<DragEvent>) => void;
@@ -21,6 +22,7 @@ interface Props {
 
 const Canvas: React.FC<Props> = ({
 	postits,
+	socketApi,
 	getUserNameById,
 	handleDrag,
 	handleDragStart,
@@ -38,6 +40,7 @@ const Canvas: React.FC<Props> = ({
 						<Postit
 							key={postit.id}
 							postit={postit}
+							socketApi={socketApi}
 							isMine={userId === postit.whoIsDragging}
 							onDrag={handleDrag}
 							onDragStart={handleDragStart}

--- a/frontend/src/components/Board/Canvas/index.tsx
+++ b/frontend/src/components/Board/Canvas/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Stage, Layer } from 'react-konva';
 import { KonvaEventObject } from 'konva/lib/Node';
+import { useRecoilValue } from 'recoil';
+import userState from '@src/stores/user';
 import { CANVAS } from '@utils/constants';
 import { IPostit } from '@src/types/board';
 import { Dispatch, SetStateAction } from 'hoist-non-react-statics/node_modules/@types/react';
@@ -27,6 +29,7 @@ const Canvas: React.FC<Props> = ({
 	setClickedPostit,
 	handleModalOpen,
 }) => {
+	const userId = useRecoilValue(userState).id;
 	return (
 		<Stage width={CANVAS.WIDTH} height={CANVAS.HEIGHT}>
 			<Layer>
@@ -35,6 +38,7 @@ const Canvas: React.FC<Props> = ({
 						<Postit
 							key={postit.id}
 							postit={postit}
+							isMine={userId === postit.whoIsDragging}
 							onDrag={handleDrag}
 							onDragStart={handleDragStart}
 							onDragEnd={handleDragEnd}

--- a/frontend/src/components/Board/Modal/Create/index.tsx
+++ b/frontend/src/components/Board/Modal/Create/index.tsx
@@ -27,6 +27,7 @@ const CreatePostitModal: React.FC<Props> = ({ socketApi, modalType, clickedPosti
 			updatedPostit.color = color;
 			updatedPostit.content = content;
 			updatedPostit.updatedBy = user.id;
+			updatedPostit.whoIsUpdating = -1;
 			return updatedPostit;
 		}
 		// if (modalType === 'create')
@@ -46,9 +47,14 @@ const CreatePostitModal: React.FC<Props> = ({ socketApi, modalType, clickedPosti
 			const postit = makePostitObj(modalType, title, content);
 			// 포스트잇 객체, 요청 유저 정보, 팀 아이디
 			if (modalType === 'create') socketApi.createNewPostit(postit);
-			else if (modalType === 'update') socketApi.updatePostit(postit);
+			else if (modalType === 'update') socketApi.updateEndPostit(postit);
 			handleModalClose();
 		}
+	};
+
+	const handleClose = () => {
+		if (modalType === 'update' && clickedPostit) socketApi.updateEndPostit({ id: clickedPostit.id });
+		handleModalClose();
 	};
 
 	useEffect(() => {
@@ -58,7 +64,7 @@ const CreatePostitModal: React.FC<Props> = ({ socketApi, modalType, clickedPosti
 	}, []);
 
 	return (
-		<Modal handleModalClose={handleModalClose} handleSubmit={handleSubmit} removeSubmitButton={false}>
+		<Modal handleModalClose={handleClose} handleSubmit={handleSubmit} removeSubmitButton={false}>
 			<Container>
 				<TitleContainer>
 					<ColorPicker selectedColor={color} setSelectedColor={setColor} />

--- a/frontend/src/components/Board/Modal/Create/style.ts
+++ b/frontend/src/components/Board/Modal/Create/style.ts
@@ -12,7 +12,10 @@ export const Input = styled.input`
 export const Textarea = styled.textarea`
 	font-size: 1rem;
 	font-family: Noto Sans KR;
-	height: 12rem;
+	min-height: 12rem;
+	max-height: 12rem;
+	min-width: 100%;
+	max-width: 100%;
 	border: none;
 	&:focus-visible {
 		outline: none;

--- a/frontend/src/components/Board/Postit/index.tsx
+++ b/frontend/src/components/Board/Postit/index.tsx
@@ -13,6 +13,7 @@ const FONT_SIZE = {
 
 type Props = {
 	postit: IPostit;
+	isMine: boolean;
 	getUserNameById: (userId: number) => string;
 	onDrag: (e: KonvaEventObject<DragEvent>) => void;
 	onDragStart: (e: KonvaEventObject<DragEvent>) => void;
@@ -95,6 +96,7 @@ const Menu = ({ handleUpdateModalOpen }: { handleUpdateModalOpen: () => void }) 
 
 const Postit: React.FC<Props> = ({
 	postit,
+	isMine,
 	getUserNameById,
 	onDrag,
 	onDragStart,
@@ -116,9 +118,9 @@ const Postit: React.FC<Props> = ({
 			onDragMove={onDrag}
 			onDragStart={onDragStart}
 			onDragEnd={onDragEnd}
-			scaleX={postit.isDragging ? 1.05 : 1}
-			scaleY={postit.isDragging ? 1.05 : 1}
-			draggable
+			scaleX={postit.whoIsDragging !== -1 ? 1.05 : 1}
+			scaleY={postit.whoIsDragging !== -1 ? 1.05 : 1}
+			draggable={postit.whoIsDragging === -1 || isMine}
 		>
 			<Rect
 				width={POSTIT.WIDTH}

--- a/frontend/src/pages/BoardPage/index.tsx
+++ b/frontend/src/pages/BoardPage/index.tsx
@@ -33,7 +33,10 @@ const BoardPage: React.FC<Props> = ({ match }) => {
 	const socketApi = {
 		setUpdatedPostitList: (initPoistList: IPostit[]) => setPostits(initPoistList),
 		createNewPostit: (newPostit: IPostit) => socket.current.emit('create new postit', newPostit),
-		updatePostit: (newPostit: IPostit) => socket.current.emit('update postit', newPostit),
+		updateStartPostit: (targetId: number) =>
+			socket.current.emit('update start postit', { id: targetId, whoIsUpdating: user.id }),
+		updateEndPostit: (newPostit: IPostit) =>
+			socket.current.emit('update end postit', { ...newPostit, whoIsUpdating: -1 }),
 		deletePostit: (targetId: number) => socket.current.emit('delete postit', targetId),
 		dragPostit: (e: KonvaEventObject<DragEvent>) => {
 			const id = e.target.id();
@@ -89,7 +92,8 @@ const BoardPage: React.FC<Props> = ({ match }) => {
 			socket.current.on('join board page', (postits: IPostit[]) => socketApi.setUpdatedPostitList(postits));
 			socket.current.on('delete postit', (postits: IPostit[]) => socketApi.setUpdatedPostitList(postits));
 			socket.current.on('create new postit', (postits: IPostit) => socketApi.setUpdatedPostit(postits));
-			socket.current.on('update postit', (postit: IPostit) => socketApi.setUpdatedPostit(postit));
+			socket.current.on('update start postit', (postit: IPostit) => socketApi.setUpdatedPostit(postit));
+			socket.current.on('update end postit', (postit: IPostit) => socketApi.setUpdatedPostit(postit));
 			socket.current.on('drag postit', (postit: IPostit) => socketApi.setUpdatedPostit(postit));
 			socket.current.on('drag end postit', (postit: IPostit) => socketApi.setUpdatedPostit(postit));
 			socket.current.on('team board error', (errorMessage: string) => toast.error(errorMessage));
@@ -99,7 +103,8 @@ const BoardPage: React.FC<Props> = ({ match }) => {
 			socket.current.off('join board page');
 			socket.current.off('create new postit');
 			socket.current.off('delete postit');
-			socket.current.off('update postit');
+			socket.current.off('update start postit');
+			socket.current.off('update end postit');
 			socket.current.off('drag postit');
 			socket.current.off('drag end postit');
 			socket.current.off('team board error');

--- a/frontend/src/templates/BoardTemplate/index.tsx
+++ b/frontend/src/templates/BoardTemplate/index.tsx
@@ -49,6 +49,7 @@ const BoardTemplate: React.FC<Props> = ({
 				<Navbar />
 				<Canvas
 					postits={postits}
+					socketApi={socketApi}
 					setModalType={setModalType}
 					setClickedPostit={setClickedPostit}
 					handleModalOpen={handleModalOpen}

--- a/frontend/src/types/board.ts
+++ b/frontend/src/types/board.ts
@@ -12,10 +12,16 @@ export interface IPostit {
 	updatedBy: number;
 	updatedAt: string;
 	whoIsDragging: number;
+	whoIsUpdating: number;
 }
 
 export interface ISocketApi {
 	createNewPostit: (newPostit: any) => void;
-	updatePostit: (newPostit: any) => void;
+	updateStartPostit: (targetId: number) => void;
+	updateEndPostit: (newPostit: any) => void;
 	dragPostit: (e: KonvaEventObject<DragEvent>) => void;
+	setUpdatedPostitList: (initPoistList: IPostit[]) => void;
+	deletePostit: (targetId: number) => void;
+	dragEndPostit: (targetId: number) => void;
+	setUpdatedPostit: (newPostit: IPostit) => void;
 }

--- a/frontend/src/types/board.ts
+++ b/frontend/src/types/board.ts
@@ -11,7 +11,7 @@ export interface IPostit {
 	createdAt: string;
 	updatedBy: number;
 	updatedAt: string;
-	isDragging: boolean;
+	whoIsDragging: number;
 }
 
 export interface ISocketApi {


### PR DESCRIPTION
## 작업 내용

- [x] 포스트잇 이동 경쟁 상황 해결 `whoIsDragging`
- [x] 포스트잇 수정 경쟁 상황 해결 `whoIsUpdating`

## 주요 변경 사항

포스트잇에 원래 `boolean`타입이던 `isDragging`을 없애고, `number`타입으로 유저의 아이디를 저장할 `whoIsDragging`과 `whoIsUpdating`을 추가하였습니다.

이동의 경우 드래그 도중에는 항상 `whoIsDragging`에 본인의 유저 id를 넣어서 보내야하고, 드래그가 끝날 시 아무도 잡고 있지 않다는 뜻의 -1을 넣어서 보내야 합니다.

수정의 경우 기존의 이벤트는 '저장' 버튼을 누를 때에 작동했었으므로 modal을 띄울 때부터 lock을 하기 위해 이벤트를 `update start postit`과 `update end postit`으로 나눴습니다. 

타인이 수정 또는 이동 중인 포스트잇은 본인이 수정, 이동할 수 없습니다.

본인이 드래그하고 있는 포스트잇은 확대, 테두리 표시가 되며, 타인이 드래그하고 있는 포스트잇은 확대만 됩니다.

타인이 수정하고 있는 포스트잇은 반투명한 상태로 `~~님이 수정중`이라는 문구로 내용이 잠시 변경됩니다.
(사진 참조)

## 구현 스크린샷 (선택)

![image](https://user-images.githubusercontent.com/42960217/143233043-2511d8b7-ecef-484d-95c4-8ea80d24abb7.png)
![image](https://user-images.githubusercontent.com/42960217/143233112-c8abc406-fdfb-4864-b98e-0b8b4f008141.png)

## 궁금한점

구현 스크린샷 보시면 수정중일 때 `~~님이 수정중입니다.`라는 문구로 변경되게 했는데 이건 좀 덜 예쁜 것 같습니다.
이름을 가져와서 쓸 수 있나 확인하려고 해본거긴한데 얘를 어떻게 활용할 지 고민입니다!