### PR TITLE
[Feat/chat#130#139] 채팅 db연동, 최근 메시지 띄우기, 채팅방 목록 정렬

### DIFF
--- a/backend/src/controllers/chat-controller.ts
+++ b/backend/src/controllers/chat-controller.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import ChatRoomService from '@services/chat-room-service';
-import { messages } from '@sockets/store';
 
 const ChatController = {
 	async createChatRoom(req: Request, res: Response) {
@@ -61,17 +60,6 @@ const ChatController = {
 			const { chatRoomId, userId } = req.params;
 			await ChatRoomService.getInstance().deleteChatRoomUser(Number(chatRoomId), Number(userId));
 			res.sendStatus(204);
-		} catch (err) {
-			res.sendStatus(409);
-		}
-	},
-
-	// redis로 변경해야함, 스크롤 구현해야함
-	async getChatMessages(req: Request, res: Response) {
-		try {
-			const { chatRoomId } = req.params;
-			const message_list = messages[Number(chatRoomId)] ? messages[Number(chatRoomId)] : [];
-			res.status(200).json({ message_list });
 		} catch (err) {
 			res.sendStatus(409);
 		}

--- a/backend/src/routes/chat-router.ts
+++ b/backend/src/routes/chat-router.ts
@@ -11,6 +11,4 @@ router.get('/rooms/:chatRoomId/users', ChatController.getChatRoomUsers);
 router.post('/rooms/:chatRoomId/users', ChatController.addChatRoomUsers);
 router.delete('/rooms/:chatRoomId/users/:userId', ChatController.deleteChatRoomUser);
 
-router.get('/rooms/:chatRoomId/messages', ChatController.getChatMessages);
-
 export default router;

--- a/backend/src/sockets/chat.ts
+++ b/backend/src/sockets/chat.ts
@@ -53,9 +53,11 @@ const initChat = (socket: Socket, namespace: Namespace) => {
 			const onlineInvitedUser = Object.keys(onlineUsersInfo).find((socketId) => {
 				return onlineUsersInfo[socketId].userId === user.userId && onlineUsersInfo[socketId].teamId === teamId;
 			});
-			onlineUsersInfo[onlineInvitedUser].socket.join(`chat-${chatRoomId}`);
-			// console.log(`join chat-${chatRoomId} ${onlineInvitedUser}`);
-			socket.to(onlineInvitedUser).emit('refresh chat rooms');
+			if (onlineUsersInfo[onlineInvitedUser] && onlineUsersInfo[onlineInvitedUser].socket) {
+				onlineUsersInfo[onlineInvitedUser].socket.join(`chat-${chatRoomId}`);
+				socket.to(onlineInvitedUser).emit('refresh chat rooms');
+				// console.log(`join chat-${chatRoomId} ${onlineInvitedUser}`);
+			}
 		});
 	});
 

--- a/backend/src/sockets/chat.ts
+++ b/backend/src/sockets/chat.ts
@@ -1,15 +1,10 @@
 import { Namespace, Socket } from 'socket.io';
-import { messages, onlineUsersInfo } from './store';
-
-// eslint-disable-next-line prefer-const
-let messageIdx = 1;
-
-const saveMessage = (chatRoomId, message: MessageType) => {
-	if (!messages[chatRoomId]) messages[chatRoomId] = [message];
-	else messages[chatRoomId].push(message);
-};
+import { onlineUsersInfo } from './store';
+import Redis from '@redis/index';
 
 const initChat = (socket: Socket, namespace: Namespace) => {
+	const redisClient = new Redis();
+
 	socket.on('enter chat rooms', ({ chatRooms }: { chatRooms: { chatRoomId: number }[] }) => {
 		chatRooms.forEach(({ chatRoomId }) => {
 			socket.join(`chat-${chatRoomId}`);
@@ -24,10 +19,17 @@ const initChat = (socket: Socket, namespace: Namespace) => {
 		});
 	});
 
-	socket.on('send message', ({ content, userId, chatRoomId }) => {
-		const message: MessageType = { messageId: (messageIdx += 1), content, createdAt: new Date(), userId, chatRoomId };
-		saveMessage(chatRoomId, message);
-		namespace.in(`chat-${chatRoomId}`).emit('receive message', message);
+	socket.on('get message list', async ({ chatRoomId }) => {
+		// console.log('get message list', chatRoomId);
+		const messageList = await redisClient.get('message', chatRoomId);
+		socket.emit('receive message list', { chatRoomId, messageList });
+	});
+
+	socket.on('send message', async (messageData: MessageReqType) => {
+		const chatRoomId = messageData.chatRoomId.toString();
+		const newMessage = await makeMessageObj(messageData);
+		await redisClient.set('message', chatRoomId, newMessage);
+		namespace.in(`chat-${messageData.chatRoomId}`).emit('receive message', newMessage);
 	});
 
 	socket.on('update chat room name', ({ chatRoomId }) => {
@@ -63,6 +65,23 @@ const initChat = (socket: Socket, namespace: Namespace) => {
 		// console.log(`leave chat-${chatRoomId} ${socket.id}`);
 	});
 };
+
+const makeMessageObj = async (messageData: MessageReqType) => {
+	const id = await Redis.getNextId('message');
+	return {
+		messageId: id,
+		content: messageData.content,
+		createdAt: new Date(),
+		userId: messageData.userId,
+		chatRoomId: messageData.chatRoomId
+	};
+};
+
+export interface MessageReqType {
+	content: string;
+	userId: number;
+	chatRoomId: number;
+}
 
 export interface MessageType {
 	messageId: number;

--- a/backend/src/sockets/store.ts
+++ b/backend/src/sockets/store.ts
@@ -3,6 +3,3 @@ export const onlineUsersByTeam = {};
 
 // {socketId: {teamId(현재팀), userId, socket}, socketId: {teamId(현재팀), userId, socket}}
 export const onlineUsersInfo = {};
-
-// chatRoomId: [{	messageId, content, createdAt, userId, chatRoomId}, {	messageId, content, createdAt, userId, chatRoomId}]
-export const messages = {};

--- a/frontend/src/apis/chat.ts
+++ b/frontend/src/apis/chat.ts
@@ -98,6 +98,12 @@ export const deleteChatRoomUser = async (chatRoomId: number, userId: number): Pr
 };
 
 export const socketApi = {
+	enterChatRooms: (socket: Socket, chatRoomList: { chatRoomId: number }[]) => {
+		socket.emit('enter chat rooms', { chatRooms: chatRoomList });
+	},
+	leaveChatRooms: (socket: Socket, chatRoomList: { chatRoomId: number }[]) => {
+		socket.emit('refresh chat rooms', { chatRooms: chatRoomList });
+	},
 	createChatRoom: (socket: Socket, chatRoomId: number, userList: UserIdType[], teamId: number) => {
 		socket.emit('create chat room', { chatRoomId, userList, teamId });
 	},
@@ -109,6 +115,9 @@ export const socketApi = {
 	},
 	getMessageList: (socket: Socket, chatRoomId: number) => {
 		socket.emit('get message list', { chatRoomId });
+	},
+	getLastMessage: (socket: Socket, chatRoomList: { chatRoomId: number }[]) => {
+		socket.emit('get last messages', { chatRoomList });
 	},
 	sendMessage: (socket: Socket, content: string, userId: number, chatRoomId: number) => {
 		socket.emit('send message', { content, userId, chatRoomId });

--- a/frontend/src/apis/chat.ts
+++ b/frontend/src/apis/chat.ts
@@ -116,9 +116,6 @@ export const socketApi = {
 	getMessageList: (socket: Socket, chatRoomId: number) => {
 		socket.emit('get message list', { chatRoomId });
 	},
-	getLastMessage: (socket: Socket, chatRoomList: { chatRoomId: number }[]) => {
-		socket.emit('get last messages', { chatRoomList });
-	},
 	sendMessage: (socket: Socket, content: string, userId: number, chatRoomId: number) => {
 		socket.emit('send message', { content, userId, chatRoomId });
 	},

--- a/frontend/src/apis/chat.ts
+++ b/frontend/src/apis/chat.ts
@@ -97,19 +97,6 @@ export const deleteChatRoomUser = async (chatRoomId: number, userId: number): Pr
 	}
 };
 
-// redis 로 변경해야 함
-export const getMessageList = async (chatRoomId: number): Promise<MessageListType> => {
-	try {
-		const res = await fetchApi.get(`/api/chat/rooms/${chatRoomId}/messages`); // 스크롤 나중에
-		if (res.status === 409) throw new Error();
-		const data = await res.json();
-		return data.message_list;
-	} catch (err) {
-		toast.error('😣 메시지 가져오기에 실패하였습니다!');
-		return [];
-	}
-};
-
 export const socketApi = {
 	createChatRoom: (socket: Socket, chatRoomId: number, userList: UserIdType[], teamId: number) => {
 		socket.emit('create chat room', { chatRoomId, userList, teamId });
@@ -119,6 +106,9 @@ export const socketApi = {
 	},
 	exitChatRoom: (socket: Socket, chatRoomId: number) => {
 		socket.emit('exit chat room', { chatRoomId });
+	},
+	getMessageList: (socket: Socket, chatRoomId: number) => {
+		socket.emit('get message list', { chatRoomId });
 	},
 	sendMessage: (socket: Socket, content: string, userId: number, chatRoomId: number) => {
 		socket.emit('send message', { content, userId, chatRoomId });

--- a/frontend/src/components/Chat/ChatContent/Message/index.tsx
+++ b/frontend/src/components/Chat/ChatContent/Message/index.tsx
@@ -7,7 +7,7 @@ import { teamUsersSelector } from '@stores/team';
 import { timeToString } from '@utils/time';
 
 import { ProfileIcon } from '@components/common';
-import { Container, ChatIconWrapper, MessageContainer, InfoContainer, ImojiWraper } from './style';
+import { Container, ChatIconWrapper, MessageContainer, InfoContainer } from './style';
 
 interface Props {
 	teamId: number;
@@ -33,7 +33,6 @@ const Message: React.FC<Props> = ({ teamId, message }) => {
 						{!isMyChat() && <b>{teamUsers[message.userId].name}</b>}
 						<span>{timeToString(new Date(message.createdAt))}</span>
 					</div>
-					<ImojiWraper>👍😲</ImojiWraper>
 				</InfoContainer>
 				<span>{message.content}</span>
 			</MessageContainer>

--- a/frontend/src/components/Chat/ChatContent/index.tsx
+++ b/frontend/src/components/Chat/ChatContent/index.tsx
@@ -28,11 +28,11 @@ const ChatContent: React.FC<Props> = ({ teamId, inviteUsers, messagesEndRef, ini
 	const setChatRoomsTrigger = useSetRecoilState(chatRoomsTrigger);
 	const messageList = useRecoilValue(messageListState);
 	const [chatMode, setChatMode] = useRecoilState(chatModeState);
-	const [currentChatRoom, setCurrentChatRoom] = useRecoilState(currentChatRoomState);
+	const [currChatRoomId, setCurrChatRoomId] = useRecoilState(currentChatRoomState);
 
 	const handleEnterCheck = (e: React.KeyboardEvent) => {
 		if (e.key !== 'Enter') return;
-		if (chatMode.chatMode === 'create') {
+		if (chatMode === 'create') {
 			handleNewChatRoomCreate();
 			return;
 		}
@@ -59,21 +59,21 @@ const ChatContent: React.FC<Props> = ({ teamId, inviteUsers, messagesEndRef, ini
 		socketApi.sendMessage(socketRef.current, inputRef.current.value, myInfo.id, newChatRoomInfo.chatRoomId);
 		inputRef.current.value = '';
 		initInviteUser();
-		setChatMode({ chatMode: 'chat' });
+		setChatMode('chat');
 		setChatRoomsTrigger((trigger) => trigger + 1);
-		setCurrentChatRoom({ currChatRoomId: newChatRoomInfo.chatRoomId });
+		setCurrChatRoomId(newChatRoomInfo.chatRoomId);
 	};
 
 	const handleSendMessage = () => {
 		if (!inputRef.current) return;
 		if (inputRef.current.value === '') return;
-		socketApi.sendMessage(socketRef.current, inputRef.current.value, myInfo.id, currentChatRoom.currChatRoomId);
+		socketApi.sendMessage(socketRef.current, inputRef.current.value, myInfo.id, currChatRoomId);
 		inputRef.current.value = '';
 	};
 
 	return (
 		<Container>
-			{chatMode.chatMode === 'chat' ? (
+			{chatMode === 'chat' ? (
 				<MessagesContainer>
 					{messageList.map((message) => (
 						<Message key={message.messageId} message={message} teamId={teamId} />
@@ -88,7 +88,7 @@ const ChatContent: React.FC<Props> = ({ teamId, inviteUsers, messagesEndRef, ini
 			)}
 			<InputContainer>
 				<input type='text' placeholder='새 메시지 입력' ref={inputRef} onKeyPress={handleEnterCheck} />
-				<FaTelegramPlane onClick={chatMode.chatMode === 'create' ? handleNewChatRoomCreate : handleSendMessage} />
+				<FaTelegramPlane onClick={chatMode === 'create' ? handleNewChatRoomCreate : handleSendMessage} />
 			</InputContainer>
 		</Container>
 	);

--- a/frontend/src/components/Chat/ChatHeader/Dropdown/InviteDropdown.tsx
+++ b/frontend/src/components/Chat/ChatHeader/Dropdown/InviteDropdown.tsx
@@ -29,7 +29,7 @@ const InviteDropdown: React.FC<Props> = ({
 	handleDropdownMode,
 }) => {
 	const socketRef = useContext(SocketContext);
-	const { currChatRoomId } = useRecoilValue(currentChatRoomState);
+	const currChatRoomId = useRecoilValue(currentChatRoomState);
 	const setChatRoomUsersTrigger = useSetRecoilState(chatRoomUsersTrigger);
 
 	const handleInviteUsers = () => {

--- a/frontend/src/components/Chat/ChatHeader/Dropdown/UpdateDropdown.tsx
+++ b/frontend/src/components/Chat/ChatHeader/Dropdown/UpdateDropdown.tsx
@@ -18,23 +18,23 @@ interface Props {
 const UpdateDropdown: React.FC<Props> = ({ teamId, handleDropdownMode }) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const socketRef = useContext(SocketContext);
-	const currentChatRoomId = useRecoilValue(currentChatRoomState).currChatRoomId;
+	const currChatRoomId = useRecoilValue(currentChatRoomState);
 	const chatRooms = useRecoilValue(chatRoomsSelector(teamId));
 	const setChatRoomsTrigger = useSetRecoilState(chatRoomsTrigger);
 
 	const handleChatRoomNameUpdate = () => {
 		if (!inputRef.current) return;
 		if (inputRef.current.value === '') return;
-		const updatedResult = updateChatRoomName(currentChatRoomId, inputRef.current.value);
+		const updatedResult = updateChatRoomName(currChatRoomId, inputRef.current.value);
 		if (!updatedResult) return;
-		socketApi.updateChatRoomName(socketRef.current, currentChatRoomId);
+		socketApi.updateChatRoomName(socketRef.current, currChatRoomId);
 		setChatRoomsTrigger((trigger) => trigger + 1);
 		handleDropdownMode('none');
 	};
 	return (
 		<UpdateDropdownContainer>
 			<h3>채팅방 이름 변경</h3>
-			<input type='text' defaultValue={chatRooms[currentChatRoomId].chatRoomName} ref={inputRef} />
+			<input type='text' defaultValue={chatRooms[currChatRoomId].chatRoomName} ref={inputRef} />
 			<ButttonContainer>
 				<Button
 					text='변경'

--- a/frontend/src/components/Chat/ChatHeader/Header/RoomHeader.tsx
+++ b/frontend/src/components/Chat/ChatHeader/Header/RoomHeader.tsx
@@ -31,7 +31,7 @@ interface Props {
 
 const RoomHeader: React.FC<Props> = ({ teamId, inviteUsers, addInviteUser, deleteInviteUser, initInviteUser }) => {
 	const socketRef = useContext(SocketContext);
-	const { currChatRoomId } = useRecoilValue(currentChatRoomState);
+	const currChatRoomId = useRecoilValue(currentChatRoomState);
 	const resetCurrChatRoom = useResetRecoilState(currentChatRoomState);
 	const setChatMode = useSetRecoilState(chatModeState);
 	const setChatRoomsTrigger = useSetRecoilState(chatRoomsTrigger);
@@ -47,7 +47,7 @@ const RoomHeader: React.FC<Props> = ({ teamId, inviteUsers, addInviteUser, delet
 		const deleteResult = await deleteChatRoomUser(currChatRoomId, myId);
 		if (!deleteResult) return;
 		socketApi.exitChatRoom(socketRef.current, currChatRoomId);
-		setChatMode({ chatMode: 'none' });
+		setChatMode('none');
 		resetCurrChatRoom();
 		setChatRoomsTrigger((trigger) => trigger + 1);
 	};

--- a/frontend/src/components/Chat/ChatHeader/SearchInput/index.tsx
+++ b/frontend/src/components/Chat/ChatHeader/SearchInput/index.tsx
@@ -20,7 +20,7 @@ interface Props {
 const SearchInput: React.FC<Props> = ({ teamId, inviteUsers, addInviteUser, deleteInviteUser }) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const myId = useRecoilValue(userState).id;
-	const { chatMode } = useRecoilValue(chatModeState);
+	const chatMode = useRecoilValue(chatModeState);
 	const teamUsers = useRecoilValue<TeamUsersType>(teamUsersSelector(teamId));
 	const chatRoomUserList = useRecoilValue(chatRoomUsersSelector).userList;
 	const [userSearchResult, setUserSearchResult] = useState<TeamUserType[]>([]);

--- a/frontend/src/components/Chat/ChatHeader/index.tsx
+++ b/frontend/src/components/Chat/ChatHeader/index.tsx
@@ -19,8 +19,8 @@ interface Props {
 
 const ChatHeader: React.FC<Props> = ({ teamId, inviteUsers, addInviteUser, deleteInviteUser, initInviteUser }) => {
 	const chatRooms = useRecoilValue<ChatRoomsType>(chatRoomsSelector(teamId));
-	const { currChatRoomId } = useRecoilValue(currentChatRoomState);
-	const { chatMode } = useRecoilValue(chatModeState);
+	const currChatRoomId = useRecoilValue(currentChatRoomState);
+	const chatMode = useRecoilValue(chatModeState);
 
 	const checkRoomAndTeam = () => chatRooms[currChatRoomId] !== undefined;
 

--- a/frontend/src/components/Chat/ChatSidebar/index.tsx
+++ b/frontend/src/components/Chat/ChatSidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState, useRecoilState } from 'recoil';
 
 import { timeSince } from '@utils/time';
 import { MessageType } from '@src/types/chat';
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const ChatSidebar: React.FC<Props> = ({ teamId }) => {
-	const setCurrentChatRoom = useSetRecoilState(currentChatRoomState);
+	const [currChatRoomId, setCurrChatRoomId] = useRecoilState(currentChatRoomState);
 	const setChatMode = useSetRecoilState(chatModeState);
 	const chatRooms = useRecoilValue(chatRoomsSelector(teamId));
 	const teamUsers = useRecoilValue(teamUsersSelector(teamId));
@@ -23,8 +23,8 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 	const [sortedMessageList, setSortedMessageList] = useState<MessageType[]>([]);
 
 	const handleEnterChatRoom = (chatRoomId: number) => {
-		setCurrentChatRoom({ currChatRoomId: chatRoomId });
-		setChatMode({ chatMode: 'chat' });
+		setCurrChatRoomId(chatRoomId);
+		setChatMode('chat');
 	};
 
 	useEffect(() => {
@@ -37,10 +37,10 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 	return (
 		<Sidebar>
 			<SidebarHeader>
-				<button type='button' onClick={() => setChatMode({ chatMode: 'none' })}>
+				<button type='button' onClick={() => setChatMode('none')}>
 					채팅
 				</button>
-				<NewChatBtn onClick={() => setChatMode({ chatMode: 'create' })}>
+				<NewChatBtn onClick={() => setChatMode('create')}>
 					<BiListPlus />
 				</NewChatBtn>
 			</SidebarHeader>
@@ -48,7 +48,11 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 				{sortedMessageList.map((message) => (
 					<>
 						{chatRooms[message.chatRoomId] && (
-							<ChatRoom key={message.chatRoomId} focus={false} onClick={() => handleEnterChatRoom(message.chatRoomId)}>
+							<ChatRoom
+								key={message.chatRoomId}
+								focus={message.chatRoomId === currChatRoomId}
+								onClick={() => handleEnterChatRoom(message.chatRoomId)}
+							>
 								<ProfileIcon
 									name={
 										chatRooms[message.chatRoomId] && chatRooms[message.chatRoomId].chatRoomName

--- a/frontend/src/components/Chat/ChatSidebar/index.tsx
+++ b/frontend/src/components/Chat/ChatSidebar/index.tsx
@@ -28,11 +28,10 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 	};
 
 	useEffect(() => {
-		const messageList = Object.values(lastMessages).sort(
+		const lastMessageList = Object.values(lastMessages).sort(
 			(a: MessageType, b: MessageType) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
 		);
-		setSortedMessageList(messageList);
-		console.log(messageList, chatRooms);
+		setSortedMessageList(lastMessageList);
 	}, [lastMessages]);
 
 	return (
@@ -47,24 +46,36 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 			</SidebarHeader>
 			<ChatRoomsContainer>
 				{sortedMessageList.map((message) => (
-					<ChatRoom key={message.chatRoomId} focus={false} onClick={() => handleEnterChatRoom(message.chatRoomId)}>
-						<ProfileIcon
-							name={chatRooms[message.chatRoomId].chatRoomName}
-							color={message.chatRoomId % 6}
-							status='none'
-							width={3.2}
-							isHover={false}
-						/>
-						<ChatRoomInfoContainer>
-							<ChatRoomInfo>
-								<h3>{chatRooms[message.chatRoomId].chatRoomName}</h3>
-								<span>{timeSince(new Date(message.createdAt))}</span>
-							</ChatRoomInfo>
-							<span>{`${teamUsers[message.userId] ? teamUsers[message.userId].name : '알 수 없음'}: ${
-								message.content
-							}`}</span>
-						</ChatRoomInfoContainer>
-					</ChatRoom>
+					<>
+						{chatRooms[message.chatRoomId] && (
+							<ChatRoom key={message.chatRoomId} focus={false} onClick={() => handleEnterChatRoom(message.chatRoomId)}>
+								<ProfileIcon
+									name={
+										chatRooms[message.chatRoomId] && chatRooms[message.chatRoomId].chatRoomName
+											? chatRooms[message.chatRoomId].chatRoomName
+											: ''
+									}
+									color={message.chatRoomId % 6}
+									status='none'
+									width={3.2}
+									isHover={false}
+								/>
+								<ChatRoomInfoContainer>
+									<ChatRoomInfo>
+										<h3>
+											{chatRooms[message.chatRoomId] && chatRooms[message.chatRoomId].chatRoomName
+												? chatRooms[message.chatRoomId].chatRoomName
+												: ''}
+										</h3>
+										<span>{timeSince(new Date(message.createdAt))}</span>
+									</ChatRoomInfo>
+									<span>{`${teamUsers[message.userId] ? teamUsers[message.userId].name : '알 수 없음'}: ${
+										message.content
+									}`}</span>
+								</ChatRoomInfoContainer>
+							</ChatRoom>
+						)}
+					</>
 				))}
 			</ChatRoomsContainer>
 		</Sidebar>

--- a/frontend/src/components/Chat/ChatSidebar/index.tsx
+++ b/frontend/src/components/Chat/ChatSidebar/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { timeSince } from '@utils/time';
-import { TeamUsersType } from '@src/types/team';
+import { MessageType } from '@src/types/chat';
 import { teamUsersSelector } from '@stores/team';
-import { chatModeState, chatRoomsSelector, currentChatRoomState } from '@stores/chat';
+import { chatModeState, chatRoomsSelector, currentChatRoomState, LastMessagesState } from '@stores/chat';
 
 import { BiListPlus } from 'react-icons/bi';
 import { Sidebar, ProfileIcon } from '@components/common';
@@ -19,13 +19,21 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 	const setChatMode = useSetRecoilState(chatModeState);
 	const chatRooms = useRecoilValue(chatRoomsSelector(teamId));
 	const teamUsers = useRecoilValue(teamUsersSelector(teamId));
+	const lastMessages = useRecoilValue(LastMessagesState);
+	const [sortedMessageList, setSortedMessageList] = useState<MessageType[]>([]);
 
 	const handleEnterChatRoom = (chatRoomId: number) => {
-		setCurrentChatRoom(() => {
-			return { currChatRoomId: chatRoomId };
-		});
+		setCurrentChatRoom({ currChatRoomId: chatRoomId });
 		setChatMode({ chatMode: 'chat' });
 	};
+
+	useEffect(() => {
+		const messageList = Object.values(lastMessages).sort(
+			(a: MessageType, b: MessageType) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+		);
+		setSortedMessageList(messageList);
+		console.log(messageList, chatRooms);
+	}, [lastMessages]);
 
 	return (
 		<Sidebar>
@@ -38,22 +46,23 @@ const ChatSidebar: React.FC<Props> = ({ teamId }) => {
 				</NewChatBtn>
 			</SidebarHeader>
 			<ChatRoomsContainer>
-				{Object.values(chatRooms).map((chatRoom) => (
-					<ChatRoom key={chatRoom.chatRoomId} focus={false} onClick={() => handleEnterChatRoom(chatRoom.chatRoomId)}>
+				{sortedMessageList.map((message) => (
+					<ChatRoom key={message.chatRoomId} focus={false} onClick={() => handleEnterChatRoom(message.chatRoomId)}>
 						<ProfileIcon
-							name={chatRoom.chatRoomName}
-							color={chatRoom.chatRoomId % 6}
+							name={chatRooms[message.chatRoomId].chatRoomName}
+							color={message.chatRoomId % 6}
 							status='none'
 							width={3.2}
 							isHover={false}
 						/>
 						<ChatRoomInfoContainer>
 							<ChatRoomInfo>
-								<h3>{chatRoom.chatRoomName}</h3>
-								<span>{timeSince(new Date())}</span>
+								<h3>{chatRooms[message.chatRoomId].chatRoomName}</h3>
+								<span>{timeSince(new Date(message.createdAt))}</span>
 							</ChatRoomInfo>
-							{/* teamUsers[lastMessage.userId].name */}
-							<span>{`${'이름'}: ${'내용'}`}</span>
+							<span>{`${teamUsers[message.userId] ? teamUsers[message.userId].name : '알 수 없음'}: ${
+								message.content
+							}`}</span>
 						</ChatRoomInfoContainer>
 					</ChatRoom>
 				))}

--- a/frontend/src/pages/ChatPage/index.tsx
+++ b/frontend/src/pages/ChatPage/index.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from 'react-router';
 import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { UserIdType } from '@src/types/team';
-import { MessageType } from '@src/types/chat';
+import { LastMessagesType, MessageType } from '@src/types/chat';
 import {
 	chatRoomsSelector,
 	currentChatRoomState,
@@ -11,6 +11,7 @@ import {
 	chatRoomsTrigger,
 	chatModeState,
 	chatRoomUsersTrigger,
+	LastMessagesState,
 } from '@stores/chat';
 import { SocketContext } from '@utils/socketContext';
 import { socketApi } from '@src/apis/chat';
@@ -52,18 +53,21 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 	const setChatRoomsTrigger = useSetRecoilState(chatRoomsTrigger);
 	const setChatRoomUsersTrigger = useSetRecoilState(chatRoomUsersTrigger);
 	const setChatMode = useSetRecoilState(chatModeState);
+	const setLastMessages = useSetRecoilState(LastMessagesState);
 
 	const addInviteUser = (newUser: UserIdType) => dispatchInviteUsers({ type: 'ADD', newUser });
 	const deleteInviteUser = (id: number) => dispatchInviteUsers({ type: 'DELETE', id });
 	const initInviteUser = () => dispatchInviteUsers({ type: 'INIT' });
 
 	const chatRoomIdList = Object.keys(chatRooms).map((chatRoomId) => {
-		return { chatRoomId };
+		return { chatRoomId: Number(chatRoomId) };
 	});
 
 	const scrollToBottom = () => messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
 
 	useEffect(() => {
+		console.log('chatRooms', chatRooms);
+		setLastMessages({});
 		resetCurrentChatRoom();
 		setChatMode({ chatMode: 'none' });
 		initInviteUser();
@@ -74,7 +78,7 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 	}, [messageList]);
 
 	useEffect(() => {
-		if (currChatRoomId !== -1) {
+		if (socketRef.current && currChatRoomId !== -1) {
 			socketApi.getMessageList(socketRef.current, currChatRoomId);
 			socketRef.current.on(
 				'receive message list',
@@ -82,11 +86,17 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 					if (chatRoomId === currChatRoomId) setMessageList([...messageList]);
 				},
 			);
-			socketRef.current.on('receive message', (message: MessageType) => {
-				if (message.chatRoomId === currChatRoomId) setMessageList((prev) => [...prev, message]);
-			});
 			socketRef.current.on('refresh chat room users', ({ chatRoomId }: { chatRoomId: number }) => {
 				if (chatRoomId === currChatRoomId) setChatRoomUsersTrigger((trigger) => trigger + 1);
+			});
+		}
+		if (socketRef.current) {
+			socketRef.current.on('receive message', (message: MessageType) => {
+				setLastMessages((prev) => {
+					const { chatRoomId } = message;
+					return { ...prev, [chatRoomId]: message };
+				});
+				if (message.chatRoomId === currChatRoomId) setMessageList((prev) => [...prev, message]);
 			});
 		}
 		return () => {
@@ -94,15 +104,21 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 			socketRef.current.off('receive message');
 			socketRef.current.off('refresh chat room users');
 		};
-	}, [currChatRoomId]);
+	}, [socketRef.current, currChatRoomId]);
 
 	useEffect(() => {
 		if (socketRef.current) {
-			socketRef.current.emit('enter chat rooms', { chatRooms: chatRoomIdList });
+			socketApi.enterChatRooms(socketRef.current, chatRoomIdList);
+			socketApi.getLastMessage(socketRef.current, chatRoomIdList);
+			socketRef.current.on('receive last messages', (lastMessages: LastMessagesType) => {
+				setLastMessages(lastMessages);
+				console.log(lastMessages);
+			});
 			socketRef.current.on('refresh chat rooms', () => setChatRoomsTrigger((trigger) => trigger + 1));
 		}
 		return () => {
-			socketRef.current.emit('leave chat rooms', { chatRooms: chatRoomIdList });
+			socketApi.leaveChatRooms(socketRef.current, chatRoomIdList);
+			socketRef.current.off('receive last message list');
 			socketRef.current.off('refresh chat rooms');
 		};
 	}, [socketRef.current, teamId]);

--- a/frontend/src/pages/ChatPage/index.tsx
+++ b/frontend/src/pages/ChatPage/index.tsx
@@ -66,8 +66,6 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 	const scrollToBottom = () => messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
 
 	useEffect(() => {
-		console.log('chatRooms', chatRooms);
-		setLastMessages({});
 		resetCurrentChatRoom();
 		setChatMode({ chatMode: 'none' });
 		initInviteUser();
@@ -109,16 +107,12 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 	useEffect(() => {
 		if (socketRef.current) {
 			socketApi.enterChatRooms(socketRef.current, chatRoomIdList);
-			socketApi.getLastMessage(socketRef.current, chatRoomIdList);
-			socketRef.current.on('receive last messages', (lastMessages: LastMessagesType) => {
-				setLastMessages(lastMessages);
-				console.log(lastMessages);
-			});
+			socketRef.current.on('receive last messages', (lastMessages: LastMessagesType) => setLastMessages(lastMessages));
 			socketRef.current.on('refresh chat rooms', () => setChatRoomsTrigger((trigger) => trigger + 1));
 		}
 		return () => {
 			socketApi.leaveChatRooms(socketRef.current, chatRoomIdList);
-			socketRef.current.off('receive last message list');
+			socketRef.current.off('receive last messages');
 			socketRef.current.off('refresh chat rooms');
 		};
 	}, [socketRef.current, teamId]);

--- a/frontend/src/pages/ChatPage/index.tsx
+++ b/frontend/src/pages/ChatPage/index.tsx
@@ -48,7 +48,7 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 
 	const [messageList, setMessageList] = useRecoilState(messageListState);
 	const chatRooms = useRecoilValue(chatRoomsSelector(teamId));
-	const { currChatRoomId } = useRecoilValue(currentChatRoomState);
+	const currChatRoomId = useRecoilValue(currentChatRoomState);
 	const resetCurrentChatRoom = useResetRecoilState(currentChatRoomState);
 	const setChatRoomsTrigger = useSetRecoilState(chatRoomsTrigger);
 	const setChatRoomUsersTrigger = useSetRecoilState(chatRoomUsersTrigger);
@@ -67,7 +67,7 @@ const ChatPage: React.FC<Props> = ({ match }) => {
 
 	useEffect(() => {
 		resetCurrentChatRoom();
-		setChatMode({ chatMode: 'none' });
+		setChatMode('none');
 		initInviteUser();
 	}, [teamId]);
 

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -5,12 +5,12 @@ import userState from './user';
 
 export const chatModeState = atom({
 	key: 'chatModeState',
-	default: { chatMode: 'none' },
+	default: 'none',
 });
 
 export const currentChatRoomState = atom({
 	key: 'currentChatRoomState',
-	default: { currChatRoomId: -1 },
+	default: -1,
 });
 
 export const chatRoomsTrigger = atom({
@@ -43,8 +43,8 @@ export const chatRoomUsersSelector = selector({
 	key: 'chatRoomUsersSelector',
 	get: async ({ get }) => {
 		get(chatRoomUsersTrigger);
-		if (get(currentChatRoomState).currChatRoomId !== -1) {
-			const data = await getChatRoomUsers(get(currentChatRoomState).currChatRoomId);
+		if (get(currentChatRoomState) !== -1) {
+			const data = await getChatRoomUsers(get(currentChatRoomState));
 			return data;
 		}
 		return { userList: [] };

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -1,5 +1,5 @@
 import { atom, selector, selectorFamily } from 'recoil';
-import { ChatRoomsLastMessageType, MessageListType } from '@src/types/chat';
+import { LastMessagesType, MessageListType } from '@src/types/chat';
 import { getChatRooms, getChatRoomUsers } from '@apis/chat';
 import userState from './user';
 
@@ -29,9 +29,9 @@ export const chatRoomsSelector = selectorFamily({
 		},
 });
 
-export const chatRoomsLastMessageState = atom({
-	key: 'chatRoomsLastMessageState',
-	default: {} as ChatRoomsLastMessageType,
+export const LastMessagesState = atom({
+	key: 'LastMessagesState',
+	default: {} as LastMessagesType,
 });
 
 export const chatRoomUsersTrigger = atom({

--- a/frontend/src/templates/ChatTemplate/index.tsx
+++ b/frontend/src/templates/ChatTemplate/index.tsx
@@ -27,7 +27,7 @@ const ChatTemplate: React.FC<Props> = ({
 	deleteInviteUser,
 	initInviteUser,
 }) => {
-	const { chatMode } = useRecoilValue(chatModeState);
+	const chatMode = useRecoilValue(chatModeState);
 
 	return (
 		<Layout>

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -15,7 +15,7 @@ export interface ChatRoomsType {
 	[chatRoomId: number]: ChatRoomType;
 }
 
-export interface ChatRoomsLastMessageType {
+export interface LastMessagesType {
 	[chatRoomId: number]: MessageType;
 }
 

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -5,28 +5,19 @@ const TimeToSec = {
 	MonthToSec: 2678400,
 };
 
-export const timeSince = (timestamp: Date) => {
+export const timeSince = (date: Date) => {
 	const curr = new Date().getTime();
-	const prev = timestamp.getTime();
+	const prev = date.getTime();
 	const pastSec = (curr - prev) / 1000;
 
-	if (pastSec < TimeToSec.MinuteToSec) {
-		return `${pastSec.toFixed(0)}초 전`;
-	}
-	if (pastSec < TimeToSec.HourToSec) {
-		return `${(pastSec / TimeToSec.MinuteToSec).toFixed(0)}분 전`;
-	}
 	if (pastSec < TimeToSec.DayToSec) {
-		return `${(pastSec / TimeToSec.HourToSec).toFixed(0)}시간 전`;
+		return `${date.getHours()}:${date.getMinutes().toString().padStart(2, '0')}`;
 	}
-	if (pastSec < TimeToSec.MonthToSec) {
-		return `${(pastSec / TimeToSec.DayToSec).toFixed(0)}일 전`;
-	}
-	return `${timestamp.getMonth() + 1}. ${timestamp.getDate()}.`;
+	return `${date.getMonth() + 1}. ${date.getDate()}.`;
 };
 
-export const timeToString = (timestamp: Date) => {
-	return `${timestamp.getMonth() + 1}. ${timestamp.getDate()}. ${timestamp.getHours()}:${timestamp
+export const timeToString = (date: Date) => {
+	return `${date.getMonth() + 1}. ${date.getDate()}. ${date.getHours()}:${date
 		.getMinutes()
 		.toString()
 		.padStart(2, '0')}`;


### PR DESCRIPTION
## 작업 내용
- [x] 채팅 db연동
- [x] 최근 메시지 띄우기
- [x] 채팅방 목록 정렬

## 주요 변경 사항
위와 같음

## 구현 스크린샷 (선택)
![Animation1](https://user-images.githubusercontent.com/47925079/143259773-5ff8b483-af8c-4391-b4bf-2f3a4ed342d5.gif)

## 궁금한점
### 문제
- 목록에 있는 몇초전 이런 시간이 업데이트가 안됩니다 -> 일정에 실시간 바처럼 setinterval 같은걸 해야할 것 같은데 일단 다른게 문제라 패스
- 채팅에서 nav바에서 팀 이동하면 문제가 생깁니다.. 이걸로 몇시간째 삽질 중입니다..아직도 해결이 안됐네요 맘같아선 nav바에 팀선택 없애버리고 싶네요..^^!!ㅠㅡㅠ 
- 만약 하나의 유저가 여러 브라우저로 들어오면 채팅방 초대를 받았을 때 초대 refresh가 나중에 들어온 유저에게만 갈 것 같습니다.. 아무도 몰랐으면 좋겠어요