### PR TITLE
[Refactor/calendar#183] 일정 type 폴더 이동, camel snake 혼용 수정

### DIFF
--- a/frontend/src/apis/schedule.ts
+++ b/frontend/src/apis/schedule.ts
@@ -1,17 +1,6 @@
 import { toast } from 'react-toastify';
-import { ScheduleType } from '@components/Calendar/dataStructure';
+import { ScheduleType, ScheduleReqType } from '@src/types/calendar';
 import fetchApi from '@utils/fetch';
-
-export interface ScheduleReqType {
-	schedule_id?: number;
-	title?: string;
-	start_date: string;
-	end_date: string;
-	repeat_option: number;
-	repeat_count: number;
-	content?: string;
-	color: number;
-}
 
 export const getSchedules = async (teamId: number, firstDate: string, lastDate: string): Promise<ScheduleType[]> => {
 	try {

--- a/frontend/src/apis/schedule.ts
+++ b/frontend/src/apis/schedule.ts
@@ -1,5 +1,5 @@
 import { toast } from 'react-toastify';
-import { ScheduleType, ScheduleReqType } from '@src/types/calendar';
+import { ScheduleType, ScheduleReqType, ScheduleResType } from '@src/types/calendar';
 import fetchApi from '@utils/fetch';
 
 export const getSchedules = async (teamId: number, firstDate: string, lastDate: string): Promise<ScheduleType[]> => {
@@ -8,7 +8,8 @@ export const getSchedules = async (teamId: number, firstDate: string, lastDate: 
 		if (res.status === 404) throw new Error('😣 일정을 가져올 수 없습니다!');
 		else if (res.status === 403) throw new Error('😣 권한이 없습니다!');
 		const data = await res.json();
-		return data;
+		const scheduleData: ScheduleType[] = data.map(scheduleSnakeToCamel);
+		return scheduleData;
 	} catch (err) {
 		toast.error((err as Error).message);
 		return [];
@@ -21,7 +22,8 @@ export const createNewSchedule = async (teamId: number, newSchedule: ScheduleReq
 		if (res.status === 409) throw new Error('😣 일정 추가에 실패하였습니다!');
 		else if (res.status === 403) throw new Error('😣 권한이 없습니다!');
 		const data = await res.json();
-		return data;
+		const scheduleData: ScheduleType[] = data.map(scheduleSnakeToCamel);
+		return scheduleData;
 	} catch (err) {
 		toast.error((err as Error).message);
 		return [];
@@ -29,24 +31,25 @@ export const createNewSchedule = async (teamId: number, newSchedule: ScheduleReq
 };
 
 export const updateSchedule = async (
-	schedule_id: number,
+	scheduleId: number,
 	newSchedule: ScheduleReqType,
 ): Promise<ScheduleType | undefined> => {
 	try {
-		const res = await fetchApi.put(`/api/schedules/${schedule_id}`, { ...newSchedule });
+		const res = await fetchApi.put(`/api/schedules/${scheduleId}`, { ...newSchedule });
 		if (res.status === 409) throw new Error('😣 일정 수정에 실패하였습니다!');
 		else if (res.status === 403) throw new Error('😣 권한이 없습니다!');
 		const data = await res.json();
-		return data;
+		const scheduleData = scheduleSnakeToCamel(data);
+		return scheduleData;
 	} catch (err) {
 		toast.error((err as Error).message);
 		return undefined;
 	}
 };
 
-export const deleteSchedule = async (schedule_id: number): Promise<boolean> => {
+export const deleteSchedule = async (scheduleId: number): Promise<boolean> => {
 	try {
-		const res = await fetchApi.delete(`/api/schedules/${schedule_id}`);
+		const res = await fetchApi.delete(`/api/schedules/${scheduleId}`);
 		if (res.status === 409) throw new Error('😣 일정 삭제에 실패하였습니다!');
 		else if (res.status === 403) throw new Error('😣 권한이 없습니다!');
 		return true;
@@ -54,4 +57,19 @@ export const deleteSchedule = async (schedule_id: number): Promise<boolean> => {
 		toast.error((err as Error).message);
 		return false;
 	}
+};
+
+const scheduleSnakeToCamel = (schedule: ScheduleResType) => {
+	return {
+		scheduleId: schedule.schedule_id,
+		teamId: schedule.team_id,
+		title: schedule.title,
+		startDate: schedule.start_date,
+		endDate: schedule.end_date,
+		repeatId: schedule.repeat_id,
+		repeatOption: schedule.repeat_option,
+		repeatCount: schedule.repeat_count,
+		content: schedule.content,
+		color: schedule.color,
+	};
 };

--- a/frontend/src/components/Calendar/CalendarHeader/index.tsx
+++ b/frontend/src/components/Calendar/CalendarHeader/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import moment from 'moment';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { FaChevronLeft, FaChevronRight, FaCalendarAlt } from 'react-icons/fa';
+
 import { ModalMode, ModalSchedule } from '@stores/calendar';
 import { ColorCode } from '@utils/constants';
-import NewAppointmentBtn from '@components/common/Button';
+import { DateInfoType, weekContentNumber } from '@src/types/calendar';
 
-import { DateInfoType, weekContentNumber } from '../dataStructure';
+import { FaChevronLeft, FaChevronRight, FaCalendarAlt } from 'react-icons/fa';
+import NewAppointmentBtn from '@components/common/Button';
 import { Container, InfoContainer, TodayBtn, ConvertBtn, ConvertBtnContainer, ButtonContainer } from './style';
 
 interface Props {

--- a/frontend/src/components/Calendar/CalendarHeader/index.tsx
+++ b/frontend/src/components/Calendar/CalendarHeader/index.tsx
@@ -56,8 +56,8 @@ const CalendarHeader: React.FC<Props> = ({
 				<div>
 					{!isMonthly && dateInfo.isDoubleMonth ? (
 						<span>
-							{dateInfo.weeklyStartDate.getFullYear()}년 {dateInfo.weeklyStartDate.getMonth() + 1}월 -{' '}
-							{nextDateInfo().year}년 {nextDateInfo().month + 1}월
+							{`${dateInfo.weeklyStartDate.getFullYear()}년 ${dateInfo.weeklyStartDate.getMonth() + 1}월 - 
+							${nextDateInfo().year}년 ${nextDateInfo().month + 1}월`}
 						</span>
 					) : (
 						<span>

--- a/frontend/src/components/Calendar/CalendarHeader/style.ts
+++ b/frontend/src/components/Calendar/CalendarHeader/style.ts
@@ -17,6 +17,7 @@ export const Container = styled.header`
 `;
 
 export const InfoContainer = styled.div`
+	flex-shrink: 0;
 	display: flex;
 	align-items: center;
 	font-size: 0.9rem;
@@ -32,6 +33,7 @@ export const InfoContainer = styled.div`
 `;
 
 export const ButtonContainer = styled.div`
+	flex-shrink: 0;
 	display: flex;
 	align-items: center;
 	& > * {
@@ -79,6 +81,8 @@ interface btnProps {
 }
 
 export const ConvertBtnContainer = styled.div`
+	display: flex;
+	width: max-content;
 	border-radius: 8px;
 	border: 1px solid ${ColorCode.LINE2};
 `;

--- a/frontend/src/components/Calendar/CalendarModal/index.tsx
+++ b/frontend/src/components/Calendar/CalendarModal/index.tsx
@@ -1,23 +1,18 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-
 import moment from 'moment';
 import { toast } from 'react-toastify';
 
-import { FaTrashAlt, FaPencilAlt } from 'react-icons/fa';
+import { ScheduleType, ScheduleReqType } from '@src/types/calendar';
 import { ModalMode, ModalSchedule } from '@stores/calendar';
-
-import ColorPicker from '@components/common/ColorPicker';
-import DropDown from '@components/common/DropDown';
-import Modal from '@components/common/Modal';
-
-import { createNewSchedule, deleteSchedule, ScheduleReqType, updateSchedule } from '@apis/schedule';
-import { dateToFormatString, isNum } from '@utils/calendar';
+import { createNewSchedule, deleteSchedule, updateSchedule } from '@apis/schedule';
 import { PrimaryPalette } from '@utils/constants';
-import { ColorCircle } from '@components/common/ColorPicker/style';
+import { dateToFormatString, isNum } from '@utils/calendar';
 
+import { FaTrashAlt, FaPencilAlt } from 'react-icons/fa';
+import { ColorCircle } from '@components/common/ColorPicker/style';
+import { ColorPicker, DropDown, Modal } from '@components/common';
 import TimeInput from './TimeInput';
-import { ScheduleType } from '../dataStructure';
 import { FormContainer, TitleContainer, ButtonContainer } from './style';
 import 'react-datepicker/dist/react-datepicker.css';
 

--- a/frontend/src/components/Calendar/CalendarModal/index.tsx
+++ b/frontend/src/components/Calendar/CalendarModal/index.tsx
@@ -3,7 +3,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import moment from 'moment';
 import { toast } from 'react-toastify';
 
-import { ScheduleType, ScheduleReqType } from '@src/types/calendar';
+import { ScheduleType, ScheduleReqType, ScheduleModalType } from '@src/types/calendar';
 import { ModalMode, ModalSchedule } from '@stores/calendar';
 import { createNewSchedule, deleteSchedule, updateSchedule } from '@apis/schedule';
 import { PrimaryPalette } from '@utils/constants';
@@ -33,7 +33,7 @@ const CalendarModal: React.FC<Props> = ({
 }) => {
 	const repeatOptions: string[] = ['반복안함', '매일반복', '매주반복', '매월반복'];
 
-	const scheduleId = useRecoilValue(ModalSchedule).schedule_id;
+	const { scheduleId } = useRecoilValue(ModalSchedule);
 	const modalSchedule = useRecoilValue(ModalSchedule);
 	const [modalMode, setModalMode] = useRecoilState(ModalMode);
 
@@ -122,33 +122,19 @@ const CalendarModal: React.FC<Props> = ({
 		}
 	};
 
-	const setScheduleState = ({
-		title,
-		color,
-		repeat_option,
-		start_date,
-		end_date,
-		content,
-	}: {
-		title: string;
-		color: number;
-		repeat_option: number;
-		start_date: string;
-		end_date: string;
-		content: string;
-	}) => {
+	const setScheduleState = ({ title, color, repeatOption, startDate, endDate, content }: ScheduleModalType) => {
 		setSelectedColor(color);
-		setSelectedRepeat(repeat_option);
-		setSelectedDate(new Date(start_date));
-		setSelectedStartTime(new Date(start_date));
-		setSelectedEndTime(new Date(end_date));
+		setSelectedRepeat(repeatOption);
+		setSelectedDate(new Date(startDate));
+		setSelectedStartTime(new Date(startDate));
+		setSelectedEndTime(new Date(endDate));
 		setDefaultTitle(title);
 		setDefaultContent(content);
 	};
 
 	useEffect(() => {
-		const { title, color, repeat_option, start_date, end_date, content } = modalSchedule;
-		setScheduleState({ title, color, repeat_option, start_date, end_date, content });
+		const { title, color, repeatOption, startDate, endDate, content } = modalSchedule;
+		setScheduleState({ title, color, repeatOption, startDate, endDate, content });
 	}, [modalMode, modalSchedule]);
 
 	return (

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/Day.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/Day.tsx
@@ -13,8 +13,7 @@ interface Props {
 }
 
 const Day: React.FC<Props> = ({ day, idx, schedules, handleModalOpen }) => {
-	const getScheduleByDay = (day: number) => schedules.filter((obj) => new Date(obj.start_date).getDate() === day);
-
+	const getScheduleByDay = (day: number) => schedules.filter((obj) => new Date(obj.startDate).getDate() === day);
 	const setModalMode = useSetRecoilState(ModalMode);
 	const setModalSchedule = useSetRecoilState(ModalSchedule);
 	const handleScheduleClick = (schedule: ScheduleType) => {
@@ -22,13 +21,18 @@ const Day: React.FC<Props> = ({ day, idx, schedules, handleModalOpen }) => {
 		setModalSchedule(schedule);
 		handleModalOpen();
 	};
+
 	return (
 		<DayWrapper className={idx === 0 ? 'sunday' : ''}>
 			{day !== 0 ? <DayNum>{day}</DayNum> : null}
-			{getScheduleByDay(day).map((e) => {
+			{getScheduleByDay(day).map((schedule) => {
 				return (
-					<Schedule key={e.schedule_id} onClick={() => handleScheduleClick(e)} color={PrimaryPalette[e.color]}>
-						{e.title}
+					<Schedule
+						key={schedule.scheduleId}
+						onClick={() => handleScheduleClick(schedule)}
+						color={PrimaryPalette[schedule.color]}
+					>
+						{schedule.title}
 					</Schedule>
 				);
 			})}

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/Day.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/Day.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSetRecoilState } from 'recoil';
 import { PrimaryPalette } from '@utils/constants';
 import { ModalMode, ModalSchedule } from '@stores/calendar';
-import { ScheduleType } from '@components/Calendar/dataStructure';
+import { ScheduleType } from '@src/types/calendar';
 import { DayWrapper, Schedule, DayNum } from './style';
 
 interface Props {

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/Week.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/Week.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { ScheduleType } from '@components/Calendar/dataStructure';
+import { ScheduleType } from '@src/types/calendar';
 import { WeekContainer } from './style';
 import Day from './Day';
 

--- a/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/index.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/MonthContent/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { DateInfoType, ScheduleType, weekContentNumber } from '@components/Calendar/dataStructure';
+import { DateInfoType, ScheduleType, weekContentNumber } from '@src/types/calendar';
 import Week from './Week';
 import { ContentContainer } from './style';
 

--- a/frontend/src/components/Calendar/MonthlyCalendar/index.tsx
+++ b/frontend/src/components/Calendar/MonthlyCalendar/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Container } from './style';
-import { DateInfoType, ScheduleType } from '../dataStructure';
+import { DateInfoType, ScheduleType } from '@src/types/calendar';
 import MonthHeader from './MonthHeader';
 import MonthContent from './MonthContent';
+import { Container } from './style';
 
 interface MonthlyCalendarProps {
 	dateInfo: DateInfoType;

--- a/frontend/src/components/Calendar/WeeklyCalendar/ScheduleItem/index.tsx
+++ b/frontend/src/components/Calendar/WeeklyCalendar/ScheduleItem/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import { ModalMode, ModalSchedule } from '@stores/calendar';
-import { ScheduleType } from '@components/Calendar/dataStructure';
+import { ScheduleType } from '@src/types/calendar';
 import { PrimaryPalette, SecondaryPalette } from '@utils/constants';
 import { Container } from './style';
 

--- a/frontend/src/components/Calendar/WeeklyCalendar/WeekContent/index.tsx
+++ b/frontend/src/components/Calendar/WeeklyCalendar/WeekContent/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { DateInfoType, weekContentNumber, ScheduleType, TimeType } from '@components/Calendar/dataStructure';
+import { DateInfoType, weekContentNumber, ScheduleType, TimeType } from '@src/types/calendar';
 import { isTodayDate, isSameDate } from '@utils/calendar';
 import ScheduleItem from '../ScheduleItem';
 import { Container, TimeContainer, DaysContainer, DayContainer, TimeBlock, CurrTimeLine } from './style';

--- a/frontend/src/components/Calendar/WeeklyCalendar/WeekContent/index.tsx
+++ b/frontend/src/components/Calendar/WeeklyCalendar/WeekContent/index.tsx
@@ -73,13 +73,13 @@ const Schedule: React.FC<Props> = ({ dateInfo, schedules = [], handleModalOpen }
 							<TimeBlock key={uuidv4()} />
 						))}
 						{schedules
-							.filter((schedule) => isSameDate(dateInfo.weeklyStartDate, i, new Date(schedule.start_date)))
+							.filter((schedule) => isSameDate(dateInfo.weeklyStartDate, i, new Date(schedule.startDate)))
 							.map((schedule) => (
 								<ScheduleItem
-									key={schedule.schedule_id}
+									key={schedule.scheduleId}
 									schedule={schedule}
-									start={getStartY(new Date(schedule.start_date))}
-									len={getLenY(new Date(schedule.start_date), new Date(schedule.end_date))}
+									start={getStartY(new Date(schedule.startDate))}
+									len={getLenY(new Date(schedule.startDate), new Date(schedule.endDate))}
 									handleModalOpen={handleModalOpen}
 								/>
 							))}

--- a/frontend/src/components/Calendar/WeeklyCalendar/WeekHeader/index.tsx
+++ b/frontend/src/components/Calendar/WeeklyCalendar/WeekHeader/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
-import { DateInfoType, DayCode, weekContentNumber } from '@components/Calendar/dataStructure';
+import { DateInfoType, DayCode, weekContentNumber } from '@src/types/calendar';
 import { Container, DayContainer } from './style';
 
 interface Props {

--- a/frontend/src/components/Calendar/WeeklyCalendar/index.tsx
+++ b/frontend/src/components/Calendar/WeeklyCalendar/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Container } from './style';
+import { DateInfoType, ScheduleType } from '@src/types/calendar';
 import WeekHeader from './WeekHeader';
 import WeekContent from './WeekContent';
-import { DateInfoType, ScheduleType } from '../dataStructure';
+import { Container } from './style';
 
 interface Props {
 	dateInfo: DateInfoType;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -4,3 +4,6 @@ export { default as TeamIcon } from './Icons/TeamIcon';
 export { default as Navbar } from './Navbar';
 export { default as Sidebar } from './Sidebar';
 export { default as Button } from './Button';
+export { default as DropDown } from './DropDown';
+export { default as ColorPicker } from './ColorPicker';
+export { default as Modal } from './Modal';

--- a/frontend/src/pages/CalendarPage/index.tsx
+++ b/frontend/src/pages/CalendarPage/index.tsx
@@ -20,9 +20,9 @@ const schedulesReducer = (schedules: ScheduleType[], action: SchedulesAction): S
 		case 'ADD':
 			return [...schedules, ...action.newSchedules];
 		case 'DELETE':
-			return [...schedules.filter((schedule) => schedule.schedule_id !== action.id)];
+			return [...schedules.filter((schedule) => schedule.scheduleId !== action.id)];
 		case 'UPDATE':
-			return [...schedules.filter((schedule) => schedule.schedule_id !== action.id), action.newSchedule];
+			return [...schedules.filter((schedule) => schedule.scheduleId !== action.id), action.newSchedule];
 		default:
 			throw new Error();
 	}

--- a/frontend/src/pages/CalendarPage/index.tsx
+++ b/frontend/src/pages/CalendarPage/index.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { getSchedules } from '@apis/schedule';
 import { getFirstDate, getLastDate, getCurrDateInfo, getPrevDateInfo, getNextDateInfo } from '@utils/calendar';
-import { ScheduleType, DateInfoType } from '@components/Calendar/dataStructure';
+import { ScheduleType, DateInfoType } from '@src/types/calendar';
 
 import CalendarTemplate from '@templates/CalendarTemplate';
 

--- a/frontend/src/stores/calendar.ts
+++ b/frontend/src/stores/calendar.ts
@@ -10,13 +10,13 @@ export const ModalMode = atom({
 export const ModalSchedule = atom({
 	key: 'calendarModalSchedule',
 	default: {
-		schedule_id: -1,
+		scheduleId: -1,
 		color: 0,
 		title: '',
-		start_date: new Date().toString(),
-		end_date: new Date().toString(),
-		repeat_id: '',
-		repeat_option: 0,
+		startDate: new Date().toString(),
+		endDate: new Date().toString(),
+		repeatId: '',
+		repeatOption: 0,
 		content: '',
 	},
 });

--- a/frontend/src/templates/CalendarTemplate/index.tsx
+++ b/frontend/src/templates/CalendarTemplate/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DateInfoType, ScheduleType } from '@components/Calendar/dataStructure';
+import { DateInfoType, ScheduleType } from '@src/types/calendar';
 
 import { Header, Navbar } from '@components/common';
 import CalendarHeader from '@components/Calendar/CalendarHeader';

--- a/frontend/src/types/calendar.ts
+++ b/frontend/src/types/calendar.ts
@@ -6,12 +6,36 @@ export interface DateInfoType {
 }
 
 export interface ScheduleType {
+	scheduleId: number;
+	teamId: number;
+	title: string;
+	startDate: string;
+	endDate: string;
+	repeatId: string;
+	repeatOption: number;
+	repeatCount: number;
+	content: string;
+	color: number;
+}
+
+export interface ScheduleModalType {
+	title: string;
+	color: number;
+	repeatOption: number;
+	startDate: string;
+	endDate: string;
+	content: string;
+}
+
+export interface ScheduleResType {
 	schedule_id: number;
+	team_id: number;
 	title: string;
 	start_date: string;
 	end_date: string;
 	repeat_id: string;
 	repeat_option: number;
+	repeat_count: number;
 	content: string;
 	color: number;
 }

--- a/frontend/src/types/calendar.ts
+++ b/frontend/src/types/calendar.ts
@@ -16,6 +16,17 @@ export interface ScheduleType {
 	color: number;
 }
 
+export interface ScheduleReqType {
+	schedule_id?: number;
+	title?: string;
+	start_date: string;
+	end_date: string;
+	repeat_option: number;
+	repeat_count: number;
+	content?: string;
+	color: number;
+}
+
 export interface TimeType {
 	hour: number;
 	text: string;

--- a/frontend/src/utils/calendar.ts
+++ b/frontend/src/utils/calendar.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { DateInfoType } from '@components/Calendar/dataStructure';
+import { DateInfoType } from '@src/types/calendar';
 
 export const getFirstDate = (isMonthly: boolean, dateInfo: DateInfoType): string =>
 	isMonthly


### PR DESCRIPTION
## 작업 내용
- [x]  components/Calendar/datastructure 파일 types/calendar로 이동
- [x]  일정 카멜, 스네이크 혼용 표기 수정
- [x]  창 크기 줄였을 때 뭉개짐 css 수정

## 주요 변경 사항
types 폴더에 calendar.ts를 생성하여 components/Calendar/datastructure 파일을 이동시켰습니다.
카멜, 스네이크 혼용표기를 수정하였습니다. 서버에서 데이터를 받으면 apis 에서 받을 때 camel로 변경하여 넘겨줍니다.
atom도 camel로 변경하였습니다.

## 구현 스크린샷 (선택)

## 궁금한점
