### PR TITLE
[Design] 약간의 반응형

### DIFF
--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -4,6 +4,9 @@ import { ColorCode } from '@utils/constants';
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
+  html {
+    font-size: calc(0.35vw + 8.74px);
+  }
   html,
   body,
   span,

--- a/frontend/src/templates/BoardTemplate/style.ts
+++ b/frontend/src/templates/BoardTemplate/style.ts
@@ -2,5 +2,7 @@ import styled from 'styled-components';
 
 export const Layout = styled.div`
 	position: relative;
+	width: 100%;
 	height: 100%;
+	overflow: hidden;
 `;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -60,7 +60,7 @@ const TeamCard = {
 	HEIGHT: '15rem',
 };
 
-const REM = 16; // TODO: 반응형 (style과 별도로 적용)
+const REM = window.innerWidth * 0.0035 + 8.74; // 0.35vw + 8.74px
 
 // const converRemToPx = (rem: number) => rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
 


### PR DESCRIPTION
## 작업 내용
- [x] 화면 크기에 따른 폰트 크기 부여 (`@media`가 아니라 `calc()`로 부여함)
- [x] 팀 보드 페이지에서 화면 크기를 조절했을 때 스크롤이 차지하는 영역만큼 빈 영역이 생기는 것 방지

## 주요 변경 사항
스크린샷 첨부

## 구현 스크린샷 (선택)
- 기존
![image](https://user-images.githubusercontent.com/42960217/144722793-c8e8790c-4c9e-4ec4-9a88-773a6f9a7b96.png)
![image](https://user-images.githubusercontent.com/42960217/144722828-fe7bbb36-4cf3-4b5e-935d-831817fc940b.png)

- 개선
![image](https://user-images.githubusercontent.com/42960217/144722777-363a03b7-0cfa-46ab-a8fb-3123d9488721.png)
![image](https://user-images.githubusercontent.com/42960217/144722839-4a020efb-a290-4d38-abd6-f9ff040518d0.png)

